### PR TITLE
feat: 差分の視覚的表示 — 元テキスト保持＋差分ハイライト

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,6 +5,7 @@ Auto-generated from all feature plans. Last updated: 2026-03-29
 ## Active Technologies
 - TypeScript 5.9（React 19 + Vite 8） + React 19, MUI v7, Zustand, react-hook-form + Zod, verify-ai（ローカル参照） (009-diff-view-webui)
 - N/A（ブラウザ内のみ、永続化なし） (009-diff-view-webui)
+- TypeScript 5.9（React 19 + Vite 8） + React 19, MUI v7, Zustand（既存。新規依存なし） (013-visual-diff-highlight)
 
 - TypeScript 5.x（ESM） + jsdiff (`diff` ^8.0), fuzzball (`fuzzball/lite` ^2.2) (001-matching-logic)
 
@@ -24,6 +25,7 @@ npm test && npm run lint
 TypeScript 5.x（ESM）: Follow standard conventions
 
 ## Recent Changes
+- 013-visual-diff-highlight: Added TypeScript 5.9（React 19 + Vite 8） + React 19, MUI v7, Zustand（既存。新規依存なし）
 - 009-diff-view-webui: Added TypeScript 5.9（React 19 + Vite 8） + React 19, MUI v7, Zustand, react-hook-form + Zod, verify-ai（ローカル参照）
 
 - 001-matching-logic: Added TypeScript 5.x（ESM） + jsdiff (`diff` ^8.0), fuzzball (`fuzzball/lite` ^2.2)

--- a/specs/013-visual-diff-highlight/tasks.md
+++ b/specs/013-visual-diff-highlight/tasks.md
@@ -147,17 +147,17 @@ parallel_groups:
 
 ### Implementation (GREEN)
 
-- [ ] T026 RED テストを読む: `specs/013-visual-diff-highlight/red-tests/ph3-test.md`
-- [ ] T027 [P] [US1] SideBySideView コンポーネントを実装: `web/src/components/SideBySideView.tsx`
-- [ ] T028 [P] [US3] DiffViewSwitcher コンポーネントを実装: `web/src/components/DiffViewSwitcher.tsx`
-- [ ] T029 [US1] [US3] App.tsx を統合: DiffViewSwitcher + ビューモードに応じた表示切替: `web/src/App.tsx`
-- [ ] T030 コンポーネントの re-export を更新: `web/src/components/index.ts`
-- [ ] T031 `cd web && npm test` で PASS を確認 (GREEN)
+- [x] T026 RED テストを読む: `specs/013-visual-diff-highlight/red-tests/ph3-test.md`
+- [x] T027 [P] [US1] SideBySideView コンポーネントを実装: `web/src/components/SideBySideView.tsx`
+- [x] T028 [P] [US3] DiffViewSwitcher コンポーネントを実装: `web/src/components/DiffViewSwitcher.tsx`
+- [x] T029 [US1] [US3] App.tsx を統合: DiffViewSwitcher + ビューモードに応じた表示切替: `web/src/App.tsx`
+- [x] T030 コンポーネントの re-export を更新: `web/src/components/index.ts`
+- [x] T031 `cd web && npm test` で PASS を確認 (GREEN)
 
 ### Verification
 
-- [ ] T032 `cd web && npm test` で全テスト通過を確認（既存テストの回帰なし）
-- [ ] T033 フェーズ出力を生成: `specs/013-visual-diff-highlight/tasks/ph3-output.md`
+- [x] T032 `cd web && npm test` で全テスト通過を確認（既存テストの回帰なし）
+- [x] T033 フェーズ出力を生成: `specs/013-visual-diff-highlight/tasks/ph3-output.md`
 
 **Checkpoint**: Side-by-side ビューが動作し、リスト/side-by-side 切替が可能。MVP として単独デモ可能。
 

--- a/specs/013-visual-diff-highlight/tasks.md
+++ b/specs/013-visual-diff-highlight/tasks.md
@@ -195,15 +195,15 @@ parallel_groups:
 
 ### Implementation (GREEN)
 
-- [ ] T039 RED テストを読む: `specs/013-visual-diff-highlight/red-tests/ph4-test.md`
-- [ ] T040 [US2] InlineView コンポーネントを実装: `web/src/components/InlineView.tsx`
-- [ ] T041 [US2] App.tsx のビュー切替に inline ケースを追加: `web/src/App.tsx`
-- [ ] T042 `cd web && npm test` で PASS を確認 (GREEN)
+- [x] T039 RED テストを読む: `specs/013-visual-diff-highlight/red-tests/ph4-test.md`
+- [x] T040 [US2] InlineView コンポーネントを実装: `web/src/components/InlineView.tsx`
+- [x] T041 [US2] App.tsx のビュー切替に inline ケースを追加: `web/src/App.tsx`
+- [x] T042 `cd web && npm test` で PASS を確認 (GREEN)
 
 ### Verification
 
-- [ ] T043 `cd web && npm test` で全テスト通過を確認（既存テストの回帰なし）
-- [ ] T044 フェーズ出力を生成: `specs/013-visual-diff-highlight/tasks/ph4-output.md`
+- [x] T043 `cd web && npm test` で全テスト通過を確認（既存テストの回帰なし）
+- [x] T044 フェーズ出力を生成: `specs/013-visual-diff-highlight/tasks/ph4-output.md`
 
 **Checkpoint**: 3ビュー（リスト・side-by-side・インライン）すべてが動作すること
 

--- a/specs/013-visual-diff-highlight/tasks.md
+++ b/specs/013-visual-diff-highlight/tasks.md
@@ -91,19 +91,19 @@ parallel_groups:
 
 ### Implementation (GREEN)
 
-- [ ] T012 RED テストを読む: `specs/013-visual-diff-highlight/red-tests/ph2-test.md`
-- [ ] T013 [P] 型定義を作成: `web/src/utils/highlightMapper.ts`（HighlightSpan, TextSegment, DiffViewMode 型）
-- [ ] T014 [P] highlightMapper を実装: `web/src/utils/highlightMapper.ts`
+- [x] T012 RED テストを読む: `specs/013-visual-diff-highlight/red-tests/ph2-test.md`
+- [x] T013 [P] 型定義を作成: `web/src/utils/highlightMapper.ts`（HighlightSpan, TextSegment, DiffViewMode 型）
+- [x] T014 [P] highlightMapper を実装: `web/src/utils/highlightMapper.ts`
   - `findHighlightSpans(text: string, diffs: DiffItem[], side: "source" | "target"): HighlightSpan[]`
   - `splitToSegments(text: string, spans: HighlightSpan[]): TextSegment[]`
-- [ ] T015 [P] HighlightedText コンポーネントを実装: `web/src/components/HighlightedText.tsx`
-- [ ] T016 compareStore に viewMode を追加: `web/src/stores/compareStore.ts`
-- [ ] T017 `cd web && npm test` で PASS を確認 (GREEN)
+- [x] T015 [P] HighlightedText コンポーネントを実装: `web/src/components/HighlightedText.tsx`
+- [x] T016 compareStore に viewMode を追加: `web/src/stores/compareStore.ts`
+- [x] T017 `cd web && npm test` で PASS を確認 (GREEN)
 
 ### Verification
 
-- [ ] T018 `cd web && npm test` で全テスト通過を確認（既存テストの回帰なし）
-- [ ] T019 フェーズ出力を生成: `specs/013-visual-diff-highlight/tasks/ph2-output.md`
+- [x] T018 `cd web && npm test` で全テスト通過を確認（既存テストの回帰なし）
+- [x] T019 フェーズ出力を生成: `specs/013-visual-diff-highlight/tasks/ph2-output.md`
 
 **Checkpoint**: highlightMapper と HighlightedText が独立して動作すること
 

--- a/specs/013-visual-diff-highlight/tasks.md
+++ b/specs/013-visual-diff-highlight/tasks.md
@@ -223,19 +223,19 @@ parallel_groups:
 
 ### Input
 
-- [ ] T045 セットアップ分析を読む: `specs/013-visual-diff-highlight/tasks/ph1-output.md`
-- [ ] T046 前フェーズ出力を読む: `specs/013-visual-diff-highlight/tasks/ph4-output.md`
+- [x] T045 セットアップ分析を読む: `specs/013-visual-diff-highlight/tasks/ph1-output.md`
+- [x] T046 前フェーズ出力を読む: `specs/013-visual-diff-highlight/tasks/ph4-output.md`
 
 ### Implementation
 
-- [ ] T047 [P] quickstart.md の動作確認手順を実施: `specs/013-visual-diff-highlight/quickstart.md`
-- [ ] T048 [P] 不要な import やデッドコードを整理
-- [ ] T049 `cd web && npm run build` でビルド確認（TypeScript 型チェック + Vite ビルド）
+- [x] T047 [P] quickstart.md の動作確認手順を実施: `specs/013-visual-diff-highlight/quickstart.md`
+- [x] T048 [P] 不要な import やデッドコードを整理
+- [x] T049 `cd web && npm run build` でビルド確認（TypeScript 型チェック + Vite ビルド）
 
 ### Verification
 
-- [ ] T050 `cd web && npm test` で全テスト通過を確認
-- [ ] T051 フェーズ出力を生成: `specs/013-visual-diff-highlight/tasks/ph5-output.md`
+- [x] T050 `cd web && npm test` で全テスト通過を確認
+- [x] T051 フェーズ出力を生成: `specs/013-visual-diff-highlight/tasks/ph5-output.md`
 
 ---
 

--- a/specs/013-visual-diff-highlight/tasks.md
+++ b/specs/013-visual-diff-highlight/tasks.md
@@ -180,18 +180,18 @@ parallel_groups:
 
 ### Input
 
-- [ ] T034 セットアップ分析を読む: `specs/013-visual-diff-highlight/tasks/ph1-output.md`
-- [ ] T035 前フェーズ出力を読む: `specs/013-visual-diff-highlight/tasks/ph3-output.md`
+- [x] T034 セットアップ分析を読む: `specs/013-visual-diff-highlight/tasks/ph1-output.md`
+- [x] T035 前フェーズ出力を読む: `specs/013-visual-diff-highlight/tasks/ph3-output.md`
 
 ### Test Implementation (RED)
 
-- [ ] T036 [P] [US2] InlineView のテストを実装: `web/src/components/InlineView.test.tsx`
+- [x] T036 [P] [US2] InlineView のテストを実装: `web/src/components/InlineView.test.tsx`
   - source と target が上下に表示されること
   - 差分箇所がハイライトされること
   - side-by-side と同じ差分箇所がハイライトされること
   - 差分がない場合にハイライトなしで表示されること
-- [ ] T037 `cd web && npm test` で FAIL を確認 (RED)
-- [ ] T038 RED 出力を生成: `specs/013-visual-diff-highlight/red-tests/ph4-test.md`
+- [x] T037 `cd web && npm test` で FAIL を確認 (RED)
+- [x] T038 RED 出力を生成: `specs/013-visual-diff-highlight/red-tests/ph4-test.md`
 
 ### Implementation (GREEN)
 

--- a/specs/013-visual-diff-highlight/tasks.md
+++ b/specs/013-visual-diff-highlight/tasks.md
@@ -1,0 +1,344 @@
+# Tasks: 差分の視覚的表示 — 元テキスト保持＋差分ハイライト
+
+**Input**: Design documents from `/specs/013-visual-diff-highlight/`
+**Prerequisites**: plan.md (required), spec.md (required), research.md, data-model.md
+
+**Tests**: TDD は User Story フェーズで必須。各フェーズは Test Implementation (RED) → Implementation (GREEN) → Verification のワークフローに従う。
+
+**Organization**: タスクはユーザーストーリーごとにグループ化し、独立した実装・テストを可能にする。
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: 依存なし（異なるファイル、実行順序自由）
+- **[Story]**: タスクが属するユーザーストーリー（US1, US2 等）
+- 説明には正確なファイルパスを含む
+
+## User Story Summary
+
+| ID  | Title                          | Priority | FR        | Scenario                  |
+|-----|--------------------------------|----------|-----------|---------------------------|
+| US1 | Side-by-side で差分箇所を確認  | P1       | FR-1,2,5,6,7 | Side-by-side ハイライト表示 |
+| US2 | インラインビューで差分を確認   | P2       | FR-3      | 上下並列ハイライト表示     |
+| US3 | ビュー切替を行う               | P2       | FR-4,8    | 3ビュー切替UI             |
+
+> US3（ビュー切替）は US1 と密結合のため Phase 3 で US1 と同時に実装する。
+
+## Path Conventions
+
+- **Web app**: `web/src/` 配下
+- **テストコマンド**: `cd web && npm test`
+
+---
+
+## Phase 1: Setup（既存コード確認） — NO TDD
+
+<!-- EXECUTION STRATEGY
+type: setup
+executor: direct
+model: sonnet
+parallel_groups:
+  - [T001]
+  - [T002, T003, T004]
+  - [T005]
+-->
+
+**Purpose**: 既存実装の確認と変更準備
+
+- [x] T001 既存コンポーネントを確認: `web/src/components/DiffList.tsx`, `web/src/components/ResultSummary.tsx`, `web/src/App.tsx`
+- [x] T002 [P] 既存ストアを確認: `web/src/stores/compareStore.ts`
+- [x] T003 [P] 既存テーマ・テストを確認: `web/src/theme/diffColors.ts`, `web/src/components/DiffList.test.tsx`
+- [x] T004 [P] コアロジックの DiffItem 出力を確認: `src/comparator/structured.ts`, `src/comparator/index.ts`
+- [x] T005 セットアップ分析を出力: `specs/013-visual-diff-highlight/tasks/ph1-output.md`
+
+---
+
+## Phase 2: 基盤 — highlightMapper + HighlightedText + Store拡張 (TDD)
+
+<!-- EXECUTION STRATEGY
+type: tdd
+executor: subagent
+red_model: opus
+green_model: sonnet
+parallel_groups:
+  - [T007, T008, T009]
+  - [T013, T014, T015]
+-->
+
+**Goal**: 全ビューが共有する基盤ユーティリティとコンポーネントを実装する
+
+**Independent Test**: `highlightMapper` に DiffItem[] と元テキストを渡して HighlightSpan[] が正しく返ることをユニットテストで確認する
+
+### Input
+
+- [ ] T006 前フェーズ出力を読む: `specs/013-visual-diff-highlight/tasks/ph1-output.md`
+
+### Test Implementation (RED)
+
+- [ ] T007 [P] highlightMapper のテストを実装: `web/src/utils/highlightMapper.test.ts`
+  - DiffItem の sourceValue/targetValue から元テキスト内の位置を特定できること
+  - 同じ値が複数回出現する場合に順序を保持すること
+  - path が空文字の場合に行単位で検索すること
+  - 値が見つからない場合に空配列を返すこと
+- [ ] T008 [P] HighlightedText のテストを実装: `web/src/components/HighlightedText.test.tsx`
+  - TextSegment[] をハイライト付き span で描画すること
+  - ハイライトなしセグメントが通常テキストで描画されること
+  - 差分タイプに応じた色が適用されること
+- [ ] T009 [P] compareStore 拡張のテストを実装: `web/src/stores/compareStore.test.ts`
+  - viewMode のデフォルトが "side-by-side" であること
+  - setViewMode で切替可能であること
+- [ ] T010 `cd web && npm test` で FAIL を確認 (RED)
+- [ ] T011 RED 出力を生成: `specs/013-visual-diff-highlight/red-tests/ph2-test.md`
+
+### Implementation (GREEN)
+
+- [ ] T012 RED テストを読む: `specs/013-visual-diff-highlight/red-tests/ph2-test.md`
+- [ ] T013 [P] 型定義を作成: `web/src/utils/highlightMapper.ts`（HighlightSpan, TextSegment, DiffViewMode 型）
+- [ ] T014 [P] highlightMapper を実装: `web/src/utils/highlightMapper.ts`
+  - `findHighlightSpans(text: string, diffs: DiffItem[], side: "source" | "target"): HighlightSpan[]`
+  - `splitToSegments(text: string, spans: HighlightSpan[]): TextSegment[]`
+- [ ] T015 [P] HighlightedText コンポーネントを実装: `web/src/components/HighlightedText.tsx`
+- [ ] T016 compareStore に viewMode を追加: `web/src/stores/compareStore.ts`
+- [ ] T017 `cd web && npm test` で PASS を確認 (GREEN)
+
+### Verification
+
+- [ ] T018 `cd web && npm test` で全テスト通過を確認（既存テストの回帰なし）
+- [ ] T019 フェーズ出力を生成: `specs/013-visual-diff-highlight/tasks/ph2-output.md`
+
+**Checkpoint**: highlightMapper と HighlightedText が独立して動作すること
+
+---
+
+## Phase 3: US1 + US3 — Side-by-side ビュー + ビュー切替 (TDD) MVP
+
+<!-- EXECUTION STRATEGY
+type: tdd
+executor: subagent
+red_model: opus
+green_model: sonnet
+parallel_groups:
+  - [T022, T023]
+  - [T027, T028]
+-->
+
+**Goal**: Side-by-side ビューとビュー切替UIを実装し、元テキスト上で差分がハイライトされる状態を実現する
+
+**Independent Test**: 2つのテキストを比較後、side-by-side ビューで差分箇所がハイライトされ、リスト/インライン/side-by-side を切替できること
+
+### Input
+
+- [ ] T020 セットアップ分析を読む: `specs/013-visual-diff-highlight/tasks/ph1-output.md`
+- [ ] T021 前フェーズ出力を読む: `specs/013-visual-diff-highlight/tasks/ph2-output.md`
+
+### Test Implementation (RED)
+
+- [ ] T022 [P] [US1] SideBySideView のテストを実装: `web/src/components/SideBySideView.test.tsx`
+  - source と target が左右に表示されること
+  - 差分箇所がハイライトされること
+  - ハイライトが値部分のみであること（フォーマット構文を含まない）
+  - 差分がない場合にハイライトなしで表示されること
+  - 片方が空の場合に「テキストなし」が表示されること
+- [ ] T023 [P] [US3] DiffViewSwitcher のテストを実装: `web/src/components/DiffViewSwitcher.test.tsx`
+  - 3つのビューモード（list / side-by-side / inline）が表示されること
+  - クリックで viewMode が切り替わること
+  - デフォルトで side-by-side が選択されていること
+- [ ] T024 `cd web && npm test` で FAIL を確認 (RED)
+- [ ] T025 RED 出力を生成: `specs/013-visual-diff-highlight/red-tests/ph3-test.md`
+
+### Implementation (GREEN)
+
+- [ ] T026 RED テストを読む: `specs/013-visual-diff-highlight/red-tests/ph3-test.md`
+- [ ] T027 [P] [US1] SideBySideView コンポーネントを実装: `web/src/components/SideBySideView.tsx`
+- [ ] T028 [P] [US3] DiffViewSwitcher コンポーネントを実装: `web/src/components/DiffViewSwitcher.tsx`
+- [ ] T029 [US1] [US3] App.tsx を統合: DiffViewSwitcher + ビューモードに応じた表示切替: `web/src/App.tsx`
+- [ ] T030 コンポーネントの re-export を更新: `web/src/components/index.ts`
+- [ ] T031 `cd web && npm test` で PASS を確認 (GREEN)
+
+### Verification
+
+- [ ] T032 `cd web && npm test` で全テスト通過を確認（既存テストの回帰なし）
+- [ ] T033 フェーズ出力を生成: `specs/013-visual-diff-highlight/tasks/ph3-output.md`
+
+**Checkpoint**: Side-by-side ビューが動作し、リスト/side-by-side 切替が可能。MVP として単独デモ可能。
+
+---
+
+## Phase 4: US2 — インラインビュー (TDD)
+
+<!-- EXECUTION STRATEGY
+type: tdd
+executor: subagent
+red_model: opus
+green_model: sonnet
+parallel_groups:
+  - [T036]
+-->
+
+**Goal**: インライン（上下並列）ビューを追加し、3ビューすべてが機能する状態にする
+
+**Independent Test**: インラインビューに切り替えて、source と target が上下に表示され差分がハイライトされること
+
+### Input
+
+- [ ] T034 セットアップ分析を読む: `specs/013-visual-diff-highlight/tasks/ph1-output.md`
+- [ ] T035 前フェーズ出力を読む: `specs/013-visual-diff-highlight/tasks/ph3-output.md`
+
+### Test Implementation (RED)
+
+- [ ] T036 [P] [US2] InlineView のテストを実装: `web/src/components/InlineView.test.tsx`
+  - source と target が上下に表示されること
+  - 差分箇所がハイライトされること
+  - side-by-side と同じ差分箇所がハイライトされること
+  - 差分がない場合にハイライトなしで表示されること
+- [ ] T037 `cd web && npm test` で FAIL を確認 (RED)
+- [ ] T038 RED 出力を生成: `specs/013-visual-diff-highlight/red-tests/ph4-test.md`
+
+### Implementation (GREEN)
+
+- [ ] T039 RED テストを読む: `specs/013-visual-diff-highlight/red-tests/ph4-test.md`
+- [ ] T040 [US2] InlineView コンポーネントを実装: `web/src/components/InlineView.tsx`
+- [ ] T041 [US2] App.tsx のビュー切替に inline ケースを追加: `web/src/App.tsx`
+- [ ] T042 `cd web && npm test` で PASS を確認 (GREEN)
+
+### Verification
+
+- [ ] T043 `cd web && npm test` で全テスト通過を確認（既存テストの回帰なし）
+- [ ] T044 フェーズ出力を生成: `specs/013-visual-diff-highlight/tasks/ph4-output.md`
+
+**Checkpoint**: 3ビュー（リスト・side-by-side・インライン）すべてが動作すること
+
+---
+
+## Phase 5: Polish & Cross-Cutting Concerns — NO TDD
+
+<!-- EXECUTION STRATEGY
+type: polish
+executor: direct
+model: haiku
+parallel_groups:
+  - [T047, T048]
+-->
+
+**Purpose**: 品質改善・エッジケース対応・手動検証
+
+### Input
+
+- [ ] T045 セットアップ分析を読む: `specs/013-visual-diff-highlight/tasks/ph1-output.md`
+- [ ] T046 前フェーズ出力を読む: `specs/013-visual-diff-highlight/tasks/ph4-output.md`
+
+### Implementation
+
+- [ ] T047 [P] quickstart.md の動作確認手順を実施: `specs/013-visual-diff-highlight/quickstart.md`
+- [ ] T048 [P] 不要な import やデッドコードを整理
+- [ ] T049 `cd web && npm run build` でビルド確認（TypeScript 型チェック + Vite ビルド）
+
+### Verification
+
+- [ ] T050 `cd web && npm test` で全テスト通過を確認
+- [ ] T051 フェーズ出力を生成: `specs/013-visual-diff-highlight/tasks/ph5-output.md`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: 依存なし — メインエージェント直接実行
+- **基盤 (Phase 2)**: Phase 1 に依存 — speckit:tdd-generator → speckit:phase-executor
+- **US1+US3 (Phase 3)**: Phase 2 に依存 — speckit:tdd-generator → speckit:phase-executor
+- **US2 (Phase 4)**: Phase 3 に依存 — speckit:tdd-generator → speckit:phase-executor
+- **Polish (Phase 5)**: Phase 4 に依存 — speckit:phase-executor のみ
+
+### Within Each User Story Phase (TDD Flow)
+
+1. **Input**: セットアップ分析 (ph1) + 前フェーズ出力を読む
+2. **Test Implementation (RED)**: テストを先に書く → `npm test` で FAIL 確認 → RED 出力生成
+3. **Implementation (GREEN)**: RED テストを読む → 実装 → `npm test` で PASS 確認
+4. **Verification**: 回帰なし確認 → フェーズ出力生成
+
+### Agent Delegation
+
+- **Phase 1 (Setup)**: メインエージェント直接実行
+- **Phase 2〜4 (基盤/User Stories)**: speckit:tdd-generator (RED) → speckit:phase-executor (GREEN + Verification)
+- **Phase 5 (Polish)**: speckit:phase-executor のみ
+
+### [P] Marker (依存なし)
+
+`[P]` は「他のタスクに依存せず実行順序が自由」を示す。並列実行を保証するものではない。
+
+---
+
+## Phase Output & RED Test Artifacts
+
+### Directory Structure
+
+```
+specs/013-visual-diff-highlight/
+├── tasks.md                    # This file
+├── tasks/
+│   ├── ph1-output.md           # Phase 1 出力（セットアップ結果）
+│   ├── ph2-output.md           # Phase 2 出力（基盤 GREEN 結果）
+│   ├── ph3-output.md           # Phase 3 出力（US1+US3 GREEN 結果）
+│   ├── ph4-output.md           # Phase 4 出力（US2 GREEN 結果）
+│   └── ph5-output.md           # Phase 5 出力（最終）
+└── red-tests/
+    ├── ph2-test.md             # Phase 2 RED テスト結果
+    ├── ph3-test.md             # Phase 3 RED テスト結果
+    └── ph4-test.md             # Phase 4 RED テスト結果
+```
+
+### Phase Output Format
+
+| Output Type     | Template File                              |
+|-----------------|--------------------------------------------|
+| `ph1-output.md` | `.specify/templates/ph1-output-template.md` |
+| `phN-output.md` | `.specify/templates/phN-output-template.md` |
+| `phN-test.md`   | `.specify/templates/red-test-template.md`   |
+
+---
+
+## Implementation Strategy
+
+### MVP First (Phase 1 + Phase 2 + Phase 3)
+
+1. Phase 1 完了: セットアップ（既存コード確認）
+2. Phase 2 完了: 基盤（highlightMapper + HighlightedText + Store）
+3. Phase 3 完了: US1+US3（Side-by-side ビュー + ビュー切替）
+4. **STOP and VALIDATE**: `cd web && npm test` で全テスト通過を確認
+5. 手動で quickstart.md のサンプルデータで動作確認
+
+### Full Delivery
+
+1. Phase 1 → Phase 2 → Phase 3 → Phase 4 → Phase 5
+2. 各フェーズでコミット: `feat(phN): description`
+
+---
+
+## Test Coverage Rules
+
+**Boundary Test Principle**: データ変換が発生する各境界でテストを書く
+
+```
+DiffItem[] → highlightMapper → HighlightSpan[] → splitToSegments → TextSegment[] → HighlightedText → DOM
+    ↓              ↓                  ↓                   ↓                ↓              ↓
+  入力検証      位置特定テスト     セグメント分割テスト  描画テスト     統合テスト    E2Eテスト
+```
+
+**チェックリスト**:
+- [ ] highlightMapper 入力パースのテスト
+- [ ] 位置特定ロジックのテスト（重複値、空 path、見つからない場合）
+- [ ] セグメント分割のテスト
+- [ ] HighlightedText 描画のテスト
+- [ ] SideBySideView / InlineView 統合テスト
+
+---
+
+## Notes
+
+- [P] タスク = 依存なし、実行順序自由
+- [Story] ラベルは特定のユーザーストーリーへのトレーサビリティを示す
+- US3（ビュー切替）は US1 と密結合のため Phase 3 で同時実装
+- TDD: Test Implementation (RED) → FAIL 確認 → Implementation (GREEN) → PASS 確認
+- RED 出力は実装開始前に必ず生成する
+- 各フェーズ完了後にコミットする
+- チェックポイントで各ストーリーを独立して検証可能

--- a/specs/013-visual-diff-highlight/tasks.md
+++ b/specs/013-visual-diff-highlight/tasks.md
@@ -127,23 +127,23 @@ parallel_groups:
 
 ### Input
 
-- [ ] T020 セットアップ分析を読む: `specs/013-visual-diff-highlight/tasks/ph1-output.md`
-- [ ] T021 前フェーズ出力を読む: `specs/013-visual-diff-highlight/tasks/ph2-output.md`
+- [x] T020 セットアップ分析を読む: `specs/013-visual-diff-highlight/tasks/ph1-output.md`
+- [x] T021 前フェーズ出力を読む: `specs/013-visual-diff-highlight/tasks/ph2-output.md`
 
 ### Test Implementation (RED)
 
-- [ ] T022 [P] [US1] SideBySideView のテストを実装: `web/src/components/SideBySideView.test.tsx`
+- [x] T022 [P] [US1] SideBySideView のテストを実装: `web/src/components/SideBySideView.test.tsx`
   - source と target が左右に表示されること
   - 差分箇所がハイライトされること
   - ハイライトが値部分のみであること（フォーマット構文を含まない）
   - 差分がない場合にハイライトなしで表示されること
   - 片方が空の場合に「テキストなし」が表示されること
-- [ ] T023 [P] [US3] DiffViewSwitcher のテストを実装: `web/src/components/DiffViewSwitcher.test.tsx`
+- [x] T023 [P] [US3] DiffViewSwitcher のテストを実装: `web/src/components/DiffViewSwitcher.test.tsx`
   - 3つのビューモード（list / side-by-side / inline）が表示されること
   - クリックで viewMode が切り替わること
   - デフォルトで side-by-side が選択されていること
-- [ ] T024 `cd web && npm test` で FAIL を確認 (RED)
-- [ ] T025 RED 出力を生成: `specs/013-visual-diff-highlight/red-tests/ph3-test.md`
+- [x] T024 `cd web && npm test` で FAIL を確認 (RED)
+- [x] T025 RED 出力を生成: `specs/013-visual-diff-highlight/red-tests/ph3-test.md`
 
 ### Implementation (GREEN)
 

--- a/specs/013-visual-diff-highlight/tasks.md
+++ b/specs/013-visual-diff-highlight/tasks.md
@@ -70,24 +70,24 @@ parallel_groups:
 
 ### Input
 
-- [ ] T006 前フェーズ出力を読む: `specs/013-visual-diff-highlight/tasks/ph1-output.md`
+- [x] T006 前フェーズ出力を読む: `specs/013-visual-diff-highlight/tasks/ph1-output.md`
 
 ### Test Implementation (RED)
 
-- [ ] T007 [P] highlightMapper のテストを実装: `web/src/utils/highlightMapper.test.ts`
+- [x] T007 [P] highlightMapper のテストを実装: `web/src/utils/highlightMapper.test.ts`
   - DiffItem の sourceValue/targetValue から元テキスト内の位置を特定できること
   - 同じ値が複数回出現する場合に順序を保持すること
   - path が空文字の場合に行単位で検索すること
   - 値が見つからない場合に空配列を返すこと
-- [ ] T008 [P] HighlightedText のテストを実装: `web/src/components/HighlightedText.test.tsx`
+- [x] T008 [P] HighlightedText のテストを実装: `web/src/components/HighlightedText.test.tsx`
   - TextSegment[] をハイライト付き span で描画すること
   - ハイライトなしセグメントが通常テキストで描画されること
   - 差分タイプに応じた色が適用されること
-- [ ] T009 [P] compareStore 拡張のテストを実装: `web/src/stores/compareStore.test.ts`
+- [x] T009 [P] compareStore 拡張のテストを実装: `web/src/stores/compareStore.test.ts`
   - viewMode のデフォルトが "side-by-side" であること
   - setViewMode で切替可能であること
-- [ ] T010 `cd web && npm test` で FAIL を確認 (RED)
-- [ ] T011 RED 出力を生成: `specs/013-visual-diff-highlight/red-tests/ph2-test.md`
+- [x] T010 `cd web && npm test` で FAIL を確認 (RED)
+- [x] T011 RED 出力を生成: `specs/013-visual-diff-highlight/red-tests/ph2-test.md`
 
 ### Implementation (GREEN)
 

--- a/specs/013-visual-diff-highlight/tasks/ph1-output.md
+++ b/specs/013-visual-diff-highlight/tasks/ph1-output.md
@@ -1,0 +1,136 @@
+# Phase 1 Output: Setup
+
+**Date**: 2026-04-13
+**Status**: Completed
+
+## Executed Tasks
+
+- [x] T001 既存コンポーネントを確認: DiffList.tsx, ResultSummary.tsx, App.tsx
+- [x] T002 既存ストアを確認: compareStore.ts
+- [x] T003 既存テーマ・テストを確認: diffColors.ts, DiffList.test.tsx
+- [x] T004 コアロジックの DiffItem 出力を確認: structured.ts, index.ts
+- [x] T005 セットアップ分析を出力
+
+## Existing Code Analysis
+
+### web/src/App.tsx
+
+**Structure**:
+- `App`: ルートコンポーネント。`ThemeProvider` + `CssBaseline` + `Container` 内に `CompareForm`, `ResultSummary`, `DiffList` を配置
+- `result` を `useCompareStore` から取得し、存在時のみ `DiffList` を表示
+
+**Required Updates**:
+1. `DiffList` 直接表示 → `DiffViewSwitcher` + ビューモード切替ロジックに置換
+2. `source`, `target` もストアから取得して side-by-side/inline ビューに渡す
+
+### web/src/components/DiffList.tsx
+
+**Structure**:
+- `DiffList({ diffs })`: DiffItem[] をカード形式でリスト表示
+- 各カードに `data-diff-type` 属性、`diffColors` で色分け
+- `DIFF_LABELS`: added→追加, removed→欠落, changed→変更
+
+**Required Updates**: なし（既存のリストビューとしてそのまま残す）
+
+### web/src/components/ResultSummary.tsx
+
+**Structure**:
+- `ResultSummary`: 比較結果のサマリー表示（一致/不一致、スコア、差分件数）
+- `useCompareStore` から result, isComparing を取得
+
+**Required Updates**: なし
+
+### web/src/stores/compareStore.ts
+
+**Structure**:
+- `CompareState`: source, target, result, isComparing, error + setter + reset
+- `initialState`: 全フィールド空/null/false
+
+**Required Updates**:
+1. `viewMode: DiffViewMode` フィールド追加（デフォルト: "side-by-side"）
+2. `setViewMode` アクション追加
+
+### web/src/theme/diffColors.ts
+
+**Structure**:
+- `diffColors`: added(orange), removed(red), changed(blue) の background/text 色定義
+
+**Required Updates**: なし（HighlightedText からそのまま流用可能）
+
+### web/src/hooks/useCompare.ts
+
+**Structure**:
+- `useCompare`: `runCompare()` を返す。バリデーション → compare() → setResult
+
+**Required Updates**: なし
+
+### web/src/components/index.ts
+
+**Structure**:
+- CompareForm, ResultSummary, DiffList を re-export
+
+**Required Updates**: 新コンポーネント（DiffViewSwitcher, HighlightedText, SideBySideView, InlineView）の追加
+
+### src/comparator/structured.ts（コアロジック）
+
+**Structure**:
+- `compareStructured`: ヘッダー欠落チェック → カラム完全性 → 行マッチング
+- ヘッダー片方欠落時 → score: 0.4 + headers diff
+- 行マッチング: greedy matching + fuzzy 比較（token_set_ratio）
+- `diffRecords`: キー単位で added/removed/changed の DiffItem を生成
+
+**DiffItem 出力パターン**:
+- `path`: キー名（例: "価格"）またはプレフィックス（"column:価格", "rows", "headers"）
+- `sourceValue`/`targetValue`: 値の文字列表現
+- テキスト比較時: `path` は空文字、値は行テキスト
+
+### src/comparator/index.ts（比較パイプライン）
+
+**Structure**:
+- `compare()`: フォーマット検出 → 正規化 → 構造化比較 or テキスト比較 → スコアリング
+- ヘッダーミスマッチ時は構造化比較を優先
+- それ以外は構造化 vs テキストの高い方を採用
+- `buildDiffs()`: 行レベルの added/removed DiffItem を生成（path は空文字）
+
+## Existing Test Analysis
+
+- `web/src/components/DiffList.test.tsx`: DiffList の描画テスト（26ケース）。基本レンダリング、色分け、ラベル、値表示、エッジケース（null, 空文字, Unicode, HTML特殊文字, 100件）
+- `web/src/stores/compareStore.test.ts`: compareStore のテスト（source/target/result/isComparing/error/reset）
+- `web/src/components/CompareForm.test.tsx`: フォーム入力テスト
+- `web/src/components/ResultSummary.test.tsx`: サマリー表示テスト
+- `web/src/hooks/useCompare.test.ts`: useCompare フックテスト
+- `web/src/test/test-utils.tsx`: render ヘルパー（BrowserRouter ラッパー）
+
+**テスト方針**: `@testing-library/react` + `vitest` + `jsdom`。`@/test/test-utils` の `render` を使用。
+
+**Does not exist (新規作成)**:
+- `web/src/utils/highlightMapper.test.ts`
+- `web/src/components/HighlightedText.test.tsx`
+- `web/src/components/SideBySideView.test.tsx`
+- `web/src/components/InlineView.test.tsx`
+- `web/src/components/DiffViewSwitcher.test.tsx`
+
+## Technical Decisions
+
+1. **highlightMapper は web/src/utils/ に配置**: ビュー層のユーティリティとして実装。コアロジック（src/）には手を加えない（Principle 5: レイヤー分離）
+2. **DiffItem.sourceValue/targetValue の indexOf で位置特定**: 正規表現より安全で、特殊文字エスケープ不要。同一値の重複は前回マッチ位置以降を検索して対応
+3. **utils/ ディレクトリは新規作成**: 既存 web/src/ に utils/ はない。mkdir が必要
+4. **MUI ToggleButtonGroup でビュー切替**: 既存 MUI v7 依存内、1クリック切替を実現
+5. **diffColors はそのまま流用**: background/text の色定義をハイライト span の背景色に適用
+
+## Handoff to Next Phase
+
+Phase 2（基盤）で実装するもの:
+- `web/src/utils/highlightMapper.ts`: findHighlightSpans() + splitToSegments() + 型定義
+- `web/src/components/HighlightedText.tsx`: TextSegment[] → ハイライト付き span 描画
+- `web/src/stores/compareStore.ts`: viewMode + setViewMode 追加
+
+再利用可能な既存コード:
+- `diffColors` の色定義（HighlightedText で直接 import）
+- `@/test/test-utils` の render（新テストで使用）
+- `DiffItem` 型（verify-ai パッケージから import）
+
+注意点:
+- `web/src/utils/` ディレクトリは新規作成が必要
+- compareStore.test.ts は既存テストに viewMode 関連を追加する形で拡張
+- HighlightedText は MUI Box/Typography ではなく素の span でシンプルに実装（パフォーマンス重視）

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -8,6 +8,7 @@ import { ResultSummary } from "@/components/ResultSummary";
 import { DiffList } from "@/components/DiffList";
 import { DiffViewSwitcher } from "@/components/DiffViewSwitcher";
 import { SideBySideView } from "@/components/SideBySideView";
+import { InlineView } from "@/components/InlineView";
 import { useCompareStore } from "@/stores/compareStore";
 
 function App() {
@@ -35,7 +36,13 @@ function App() {
                 diffs={result.diffs}
               />
             )}
-            {viewMode === "inline" && <DiffList diffs={result.diffs} />}
+            {viewMode === "inline" && (
+              <InlineView
+                source={source}
+                target={target}
+                diffs={result.diffs}
+              />
+            )}
           </>
         )}
       </Container>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,14 +1,20 @@
 import { ThemeProvider } from "@mui/material/styles";
 import CssBaseline from "@mui/material/CssBaseline";
 import Container from "@mui/material/Container";
+import Box from "@mui/material/Box";
 import { theme } from "@/theme";
 import { CompareForm } from "@/components/CompareForm";
 import { ResultSummary } from "@/components/ResultSummary";
 import { DiffList } from "@/components/DiffList";
+import { DiffViewSwitcher } from "@/components/DiffViewSwitcher";
+import { SideBySideView } from "@/components/SideBySideView";
 import { useCompareStore } from "@/stores/compareStore";
 
 function App() {
   const result = useCompareStore((state) => state.result);
+  const source = useCompareStore((state) => state.source);
+  const target = useCompareStore((state) => state.target);
+  const viewMode = useCompareStore((state) => state.viewMode);
 
   return (
     <ThemeProvider theme={theme}>
@@ -16,7 +22,22 @@ function App() {
       <Container maxWidth="md" sx={{ py: 4 }}>
         <CompareForm />
         <ResultSummary />
-        {result && <DiffList diffs={result.diffs} />}
+        {result && (
+          <>
+            <Box sx={{ mb: 2 }}>
+              <DiffViewSwitcher />
+            </Box>
+            {viewMode === "list" && <DiffList diffs={result.diffs} />}
+            {viewMode === "side-by-side" && (
+              <SideBySideView
+                source={source}
+                target={target}
+                diffs={result.diffs}
+              />
+            )}
+            {viewMode === "inline" && <DiffList diffs={result.diffs} />}
+          </>
+        )}
       </Container>
     </ThemeProvider>
   );

--- a/web/src/components/DiffViewSwitcher.test.tsx
+++ b/web/src/components/DiffViewSwitcher.test.tsx
@@ -1,0 +1,143 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@/test/test-utils";
+import { DiffViewSwitcher } from "./DiffViewSwitcher";
+import { useCompareStore } from "@/stores/compareStore";
+import type { DiffViewMode } from "@/utils/highlightMapper";
+
+describe("DiffViewSwitcher", () => {
+  beforeEach(() => {
+    // ストアをリセットしてデフォルト状態にする
+    useCompareStore.getState().reset();
+  });
+
+  // --- 3つのビューモード表示 ---
+
+  describe("ビューモード表示", () => {
+    it("3つのビューモードボタンが表示される", () => {
+      render(<DiffViewSwitcher />);
+      expect(screen.getByRole("button", { name: /リスト/i })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /side-by-side/i })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /インライン/i })).toBeInTheDocument();
+    });
+
+    it("list ボタンが存在する", () => {
+      render(<DiffViewSwitcher />);
+      const listButton = screen.getByRole("button", { name: /リスト/i });
+      expect(listButton).toBeInTheDocument();
+    });
+
+    it("side-by-side ボタンが存在する", () => {
+      render(<DiffViewSwitcher />);
+      const sideBySideButton = screen.getByRole("button", { name: /side-by-side/i });
+      expect(sideBySideButton).toBeInTheDocument();
+    });
+
+    it("inline ボタンが存在する", () => {
+      render(<DiffViewSwitcher />);
+      const inlineButton = screen.getByRole("button", { name: /インライン/i });
+      expect(inlineButton).toBeInTheDocument();
+    });
+  });
+
+  // --- デフォルト選択 ---
+
+  describe("デフォルト選択", () => {
+    it("デフォルトで side-by-side が選択されている", () => {
+      render(<DiffViewSwitcher />);
+      const sideBySideButton = screen.getByRole("button", { name: /side-by-side/i });
+      // MUI ToggleButtonGroup では選択状態に aria-pressed="true" が付く
+      expect(sideBySideButton).toHaveAttribute("aria-pressed", "true");
+    });
+
+    it("デフォルトで list は選択されていない", () => {
+      render(<DiffViewSwitcher />);
+      const listButton = screen.getByRole("button", { name: /リスト/i });
+      expect(listButton).toHaveAttribute("aria-pressed", "false");
+    });
+
+    it("デフォルトで inline は選択されていない", () => {
+      render(<DiffViewSwitcher />);
+      const inlineButton = screen.getByRole("button", { name: /インライン/i });
+      expect(inlineButton).toHaveAttribute("aria-pressed", "false");
+    });
+  });
+
+  // --- クリックによる切替 ---
+
+  describe("クリックによるモード切替", () => {
+    it("list をクリックすると viewMode が list に変わる", () => {
+      render(<DiffViewSwitcher />);
+      const listButton = screen.getByRole("button", { name: /リスト/i });
+      fireEvent.click(listButton);
+      expect(useCompareStore.getState().viewMode).toBe("list");
+    });
+
+    it("inline をクリックすると viewMode が inline に変わる", () => {
+      render(<DiffViewSwitcher />);
+      const inlineButton = screen.getByRole("button", { name: /インライン/i });
+      fireEvent.click(inlineButton);
+      expect(useCompareStore.getState().viewMode).toBe("inline");
+    });
+
+    it("side-by-side をクリックすると viewMode が side-by-side に変わる", () => {
+      // まず別のモードに切替
+      useCompareStore.getState().setViewMode("list");
+      render(<DiffViewSwitcher />);
+      const sideBySideButton = screen.getByRole("button", { name: /side-by-side/i });
+      fireEvent.click(sideBySideButton);
+      expect(useCompareStore.getState().viewMode).toBe("side-by-side");
+    });
+
+    it("切替後に選択ボタンの aria-pressed が更新される", () => {
+      render(<DiffViewSwitcher />);
+      const listButton = screen.getByRole("button", { name: /リスト/i });
+      fireEvent.click(listButton);
+      expect(listButton).toHaveAttribute("aria-pressed", "true");
+      const sideBySideButton = screen.getByRole("button", { name: /side-by-side/i });
+      expect(sideBySideButton).toHaveAttribute("aria-pressed", "false");
+    });
+  });
+
+  // --- ストア連携 ---
+
+  describe("ストア連携", () => {
+    it("ストアの viewMode が変更されると選択状態が反映される", () => {
+      useCompareStore.getState().setViewMode("inline");
+      render(<DiffViewSwitcher />);
+      const inlineButton = screen.getByRole("button", { name: /インライン/i });
+      expect(inlineButton).toHaveAttribute("aria-pressed", "true");
+    });
+
+    it("リセット後にデフォルトの side-by-side に戻る", () => {
+      useCompareStore.getState().setViewMode("list");
+      useCompareStore.getState().reset();
+      render(<DiffViewSwitcher />);
+      const sideBySideButton = screen.getByRole("button", { name: /side-by-side/i });
+      expect(sideBySideButton).toHaveAttribute("aria-pressed", "true");
+    });
+  });
+
+  // --- エッジケース ---
+
+  describe("エッジケース", () => {
+    it("同じモードを連続クリックしても viewMode が維持される", () => {
+      render(<DiffViewSwitcher />);
+      const sideBySideButton = screen.getByRole("button", { name: /side-by-side/i });
+      fireEvent.click(sideBySideButton);
+      // 同じボタンを再度クリック - viewMode は変わらない (null にならない)
+      expect(useCompareStore.getState().viewMode).toBe("side-by-side");
+    });
+
+    it("全モードを順番に切替できる", () => {
+      render(<DiffViewSwitcher />);
+      const modes: DiffViewMode[] = ["list", "inline", "side-by-side"];
+      const labels = [/リスト/i, /インライン/i, /side-by-side/i];
+
+      for (let i = 0; i < modes.length; i++) {
+        const button = screen.getByRole("button", { name: labels[i] });
+        fireEvent.click(button);
+        expect(useCompareStore.getState().viewMode).toBe(modes[i]);
+      }
+    });
+  });
+});

--- a/web/src/components/DiffViewSwitcher.tsx
+++ b/web/src/components/DiffViewSwitcher.tsx
@@ -1,0 +1,31 @@
+import ToggleButton from "@mui/material/ToggleButton";
+import ToggleButtonGroup from "@mui/material/ToggleButtonGroup";
+import { useCompareStore } from "@/stores/compareStore";
+import type { DiffViewMode } from "@/utils/highlightMapper";
+
+export function DiffViewSwitcher() {
+  const viewMode = useCompareStore((state) => state.viewMode);
+  const setViewMode = useCompareStore((state) => state.setViewMode);
+
+  const handleChange = (
+    _event: React.MouseEvent<HTMLElement>,
+    newMode: DiffViewMode | null,
+  ) => {
+    if (newMode !== null) {
+      setViewMode(newMode);
+    }
+  };
+
+  return (
+    <ToggleButtonGroup
+      value={viewMode}
+      exclusive
+      onChange={handleChange}
+      size="small"
+    >
+      <ToggleButton value="list">リスト</ToggleButton>
+      <ToggleButton value="side-by-side">side-by-side</ToggleButton>
+      <ToggleButton value="inline">インライン</ToggleButton>
+    </ToggleButtonGroup>
+  );
+}

--- a/web/src/components/HighlightedText.test.tsx
+++ b/web/src/components/HighlightedText.test.tsx
@@ -1,7 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { render, screen } from "@/test/test-utils";
 import { HighlightedText } from "./HighlightedText";
-import { diffColors } from "@/theme/diffColors";
 import type { TextSegment } from "@/utils/highlightMapper";
 
 describe("HighlightedText", () => {

--- a/web/src/components/HighlightedText.test.tsx
+++ b/web/src/components/HighlightedText.test.tsx
@@ -1,0 +1,199 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@/test/test-utils";
+import { HighlightedText } from "./HighlightedText";
+import { diffColors } from "@/theme/diffColors";
+import type { TextSegment } from "@/utils/highlightMapper";
+
+describe("HighlightedText", () => {
+  // --- 基本レンダリング ---
+
+  describe("基本レンダリング", () => {
+    it("TextSegment[] をハイライト付き span で描画する", () => {
+      const segments: TextSegment[] = [
+        { text: "hello ", highlight: null },
+        {
+          text: "world",
+          highlight: {
+            start: 6,
+            end: 11,
+            diffType: "changed",
+            diffItem: { type: "changed", path: "x", sourceValue: "world", targetValue: "earth" },
+          },
+        },
+      ];
+      render(<HighlightedText segments={segments} />);
+      expect(screen.getByText("hello")).toBeTruthy();
+      expect(screen.getByText("world")).toBeTruthy();
+    });
+
+    it("ハイライトなしセグメントが通常テキストとして描画される", () => {
+      const segments: TextSegment[] = [
+        { text: "plain text", highlight: null },
+      ];
+      const { container } = render(<HighlightedText segments={segments} />);
+      const spans = container.querySelectorAll("span");
+      // ハイライトなしの span には背景色が設定されない
+      const plainSpan = Array.from(spans).find((s) => s.textContent === "plain text");
+      expect(plainSpan).toBeDefined();
+      expect(plainSpan?.style.backgroundColor).toBeFalsy();
+    });
+  });
+
+  // --- 差分タイプに応じた色 ---
+
+  describe("差分タイプに応じた色", () => {
+    it("added タイプのセグメントに added 色が適用される", () => {
+      const segments: TextSegment[] = [
+        {
+          text: "new value",
+          highlight: {
+            start: 0,
+            end: 9,
+            diffType: "added",
+            diffItem: { type: "added", path: "x", sourceValue: null, targetValue: "new value" },
+          },
+        },
+      ];
+      const { container } = render(<HighlightedText segments={segments} />);
+      const highlightedSpan = container.querySelector("[data-diff-type='added']");
+      expect(highlightedSpan).not.toBeNull();
+    });
+
+    it("removed タイプのセグメントに removed 色が適用される", () => {
+      const segments: TextSegment[] = [
+        {
+          text: "old value",
+          highlight: {
+            start: 0,
+            end: 9,
+            diffType: "removed",
+            diffItem: { type: "removed", path: "x", sourceValue: "old value", targetValue: null },
+          },
+        },
+      ];
+      const { container } = render(<HighlightedText segments={segments} />);
+      const highlightedSpan = container.querySelector("[data-diff-type='removed']");
+      expect(highlightedSpan).not.toBeNull();
+    });
+
+    it("changed タイプのセグメントに changed 色が適用される", () => {
+      const segments: TextSegment[] = [
+        {
+          text: "modified",
+          highlight: {
+            start: 0,
+            end: 8,
+            diffType: "changed",
+            diffItem: { type: "changed", path: "x", sourceValue: "modified", targetValue: "updated" },
+          },
+        },
+      ];
+      const { container } = render(<HighlightedText segments={segments} />);
+      const highlightedSpan = container.querySelector("[data-diff-type='changed']");
+      expect(highlightedSpan).not.toBeNull();
+    });
+
+    it("各差分タイプが異なるスタイルで表示される", () => {
+      const segments: TextSegment[] = [
+        {
+          text: "added",
+          highlight: {
+            start: 0, end: 5, diffType: "added",
+            diffItem: { type: "added", path: "a", sourceValue: null, targetValue: "added" },
+          },
+        },
+        { text: " ", highlight: null },
+        {
+          text: "removed",
+          highlight: {
+            start: 6, end: 13, diffType: "removed",
+            diffItem: { type: "removed", path: "b", sourceValue: "removed", targetValue: null },
+          },
+        },
+        { text: " ", highlight: null },
+        {
+          text: "changed",
+          highlight: {
+            start: 14, end: 21, diffType: "changed",
+            diffItem: { type: "changed", path: "c", sourceValue: "changed", targetValue: "updated" },
+          },
+        },
+      ];
+      const { container } = render(<HighlightedText segments={segments} />);
+      const addedEl = container.querySelector("[data-diff-type='added']");
+      const removedEl = container.querySelector("[data-diff-type='removed']");
+      const changedEl = container.querySelector("[data-diff-type='changed']");
+      expect(addedEl).not.toBeNull();
+      expect(removedEl).not.toBeNull();
+      expect(changedEl).not.toBeNull();
+    });
+  });
+
+  // --- エッジケース ---
+
+  describe("エッジケース", () => {
+    it("空の segments 配列で何も描画しない", () => {
+      const { container } = render(<HighlightedText segments={[]} />);
+      expect(container.textContent).toBe("");
+    });
+
+    it("空文字列のセグメントを正しく処理する", () => {
+      const segments: TextSegment[] = [
+        { text: "", highlight: null },
+        { text: "visible", highlight: null },
+      ];
+      const { container } = render(<HighlightedText segments={segments} />);
+      expect(container.textContent).toContain("visible");
+    });
+
+    it("Unicode/絵文字を含むセグメントを正しく描画する", () => {
+      const segments: TextSegment[] = [
+        {
+          text: "太郎",
+          highlight: {
+            start: 0, end: 2, diffType: "changed",
+            diffItem: { type: "changed", path: "name", sourceValue: "太郎", targetValue: "花子" },
+          },
+        },
+      ];
+      render(<HighlightedText segments={segments} />);
+      expect(screen.getByText("太郎")).toBeTruthy();
+    });
+
+    it("HTML 特殊文字がエスケープされて表示される", () => {
+      const segments: TextSegment[] = [
+        {
+          text: "<script>alert('xss')</script>",
+          highlight: {
+            start: 0, end: 29, diffType: "changed",
+            diffItem: { type: "changed", path: "x", sourceValue: "<script>alert('xss')</script>", targetValue: "safe" },
+          },
+        },
+      ];
+      render(<HighlightedText segments={segments} />);
+      expect(screen.getByText("<script>alert('xss')</script>")).toBeTruthy();
+    });
+
+    it("大量のセグメント（1000件）でもクラッシュしない", () => {
+      const segments: TextSegment[] = Array.from({ length: 1000 }, (_, i) => ({
+        text: `item${i}`,
+        highlight: i % 2 === 0 ? {
+          start: i * 5, end: i * 5 + 5, diffType: "changed" as const,
+          diffItem: { type: "changed" as const, path: `p${i}`, sourceValue: `item${i}`, targetValue: `new${i}` },
+        } : null,
+      }));
+      const { container } = render(<HighlightedText segments={segments} />);
+      expect(container.textContent).toContain("item0");
+      expect(container.textContent).toContain("item999");
+    });
+
+    it("改行を含むテキストが保持される", () => {
+      const segments: TextSegment[] = [
+        { text: "line1\nline2\nline3", highlight: null },
+      ];
+      const { container } = render(<HighlightedText segments={segments} />);
+      expect(container.textContent).toContain("line1");
+      expect(container.textContent).toContain("line3");
+    });
+  });
+});

--- a/web/src/components/HighlightedText.tsx
+++ b/web/src/components/HighlightedText.tsx
@@ -1,0 +1,34 @@
+import type { TextSegment } from "@/utils/highlightMapper";
+import { diffColors } from "@/theme/diffColors";
+
+interface HighlightedTextProps {
+  segments: TextSegment[];
+}
+
+export function HighlightedText({ segments }: HighlightedTextProps) {
+  return (
+    <>
+      {segments.map((segment, index) => {
+        if (!segment.highlight) {
+          return <span key={index}>{segment.text}</span>;
+        }
+
+        const { diffType } = segment.highlight;
+        const colors = diffColors[diffType];
+
+        return (
+          <span
+            key={index}
+            data-diff-type={diffType}
+            style={{
+              backgroundColor: colors.background,
+              color: colors.text,
+            }}
+          >
+            {segment.text}
+          </span>
+        );
+      })}
+    </>
+  );
+}

--- a/web/src/components/InlineView.test.tsx
+++ b/web/src/components/InlineView.test.tsx
@@ -1,0 +1,446 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@/test/test-utils";
+import { InlineView } from "./InlineView";
+import type { DiffItem } from "verify-ai";
+import { diffColors } from "@/theme/diffColors";
+
+describe("InlineView", () => {
+  // --- 基本レンダリング ---
+
+  describe("基本レンダリング", () => {
+    it("source と target が上下に表示される", () => {
+      const source = "name,age\nAlice,30";
+      const target = '{"name":"Alice","age":30}';
+      const diffs: DiffItem[] = [];
+      const { container } = render(
+        <InlineView source={source} target={target} diffs={diffs} />,
+      );
+      const sourcePane = container.querySelector(
+        "[data-testid='source-pane']",
+      );
+      const targetPane = container.querySelector(
+        "[data-testid='target-pane']",
+      );
+      expect(sourcePane).not.toBeNull();
+      expect(targetPane).not.toBeNull();
+      expect(sourcePane?.textContent).toContain("Alice,30");
+      expect(targetPane?.textContent).toContain('"Alice"');
+    });
+
+    it("source ペインが target ペインの上に配置される（縦レイアウト）", () => {
+      const source = "source text";
+      const target = "target text";
+      const diffs: DiffItem[] = [];
+      const { container } = render(
+        <InlineView source={source} target={target} diffs={diffs} />,
+      );
+      const sourcePane = container.querySelector(
+        "[data-testid='source-pane']",
+      );
+      const targetPane = container.querySelector(
+        "[data-testid='target-pane']",
+      );
+      expect(sourcePane).not.toBeNull();
+      expect(targetPane).not.toBeNull();
+      // source が target より前に DOM 上に存在する
+      const allPanes = container.querySelectorAll("[data-testid]");
+      const paneIds = Array.from(allPanes).map((el) =>
+        el.getAttribute("data-testid"),
+      );
+      const sourceIndex = paneIds.indexOf("source-pane");
+      const targetIndex = paneIds.indexOf("target-pane");
+      expect(sourceIndex).toBeLessThan(targetIndex);
+    });
+  });
+
+  // --- 差分ハイライト ---
+
+  describe("差分ハイライト", () => {
+    it("差分箇所がハイライトされる", () => {
+      const source = "name,age\nAlice,30";
+      const target = "name,age\nAlice,25";
+      const diffs: DiffItem[] = [
+        {
+          type: "changed",
+          path: "age",
+          sourceValue: "30",
+          targetValue: "25",
+        },
+      ];
+      const { container } = render(
+        <InlineView source={source} target={target} diffs={diffs} />,
+      );
+      const highlighted = container.querySelectorAll(
+        "[data-diff-type='changed']",
+      );
+      expect(highlighted.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("source 側で changed 値がハイライトされる", () => {
+      const source = "price: 100";
+      const target = "price: 200";
+      const diffs: DiffItem[] = [
+        {
+          type: "changed",
+          path: "price",
+          sourceValue: "100",
+          targetValue: "200",
+        },
+      ];
+      const { container } = render(
+        <InlineView source={source} target={target} diffs={diffs} />,
+      );
+      const sourcePane = container.querySelector(
+        "[data-testid='source-pane']",
+      );
+      const changedSpan = sourcePane?.querySelector(
+        "[data-diff-type='changed']",
+      );
+      expect(changedSpan).not.toBeNull();
+      expect(changedSpan?.textContent).toBe("100");
+    });
+
+    it("target 側で changed 値がハイライトされる", () => {
+      const source = "price: 100";
+      const target = "price: 200";
+      const diffs: DiffItem[] = [
+        {
+          type: "changed",
+          path: "price",
+          sourceValue: "100",
+          targetValue: "200",
+        },
+      ];
+      const { container } = render(
+        <InlineView source={source} target={target} diffs={diffs} />,
+      );
+      const targetPane = container.querySelector(
+        "[data-testid='target-pane']",
+      );
+      const changedSpan = targetPane?.querySelector(
+        "[data-diff-type='changed']",
+      );
+      expect(changedSpan).not.toBeNull();
+      expect(changedSpan?.textContent).toBe("200");
+    });
+
+    it("removed 差分で source 側のみハイライトされる", () => {
+      const source = "name,age\nBob,40";
+      const target = "name,age";
+      const diffs: DiffItem[] = [
+        {
+          type: "removed",
+          path: "name",
+          sourceValue: "Bob",
+          targetValue: null,
+        },
+      ];
+      const { container } = render(
+        <InlineView source={source} target={target} diffs={diffs} />,
+      );
+      const sourcePane = container.querySelector(
+        "[data-testid='source-pane']",
+      );
+      const targetPane = container.querySelector(
+        "[data-testid='target-pane']",
+      );
+      const sourceHighlight = sourcePane?.querySelector(
+        "[data-diff-type='removed']",
+      );
+      const targetHighlight = targetPane?.querySelector(
+        "[data-diff-type='removed']",
+      );
+      expect(sourceHighlight).not.toBeNull();
+      expect(sourceHighlight?.textContent).toBe("Bob");
+      expect(targetHighlight).toBeNull();
+    });
+
+    it("added 差分で target 側のみハイライトされる", () => {
+      const source = "name\n";
+      const target = "name\nAlice";
+      const diffs: DiffItem[] = [
+        {
+          type: "added",
+          path: "name",
+          sourceValue: null,
+          targetValue: "Alice",
+        },
+      ];
+      const { container } = render(
+        <InlineView source={source} target={target} diffs={diffs} />,
+      );
+      const sourcePane = container.querySelector(
+        "[data-testid='source-pane']",
+      );
+      const targetPane = container.querySelector(
+        "[data-testid='target-pane']",
+      );
+      const sourceHighlight = sourcePane?.querySelector(
+        "[data-diff-type='added']",
+      );
+      const targetHighlight = targetPane?.querySelector(
+        "[data-diff-type='added']",
+      );
+      expect(sourceHighlight).toBeNull();
+      expect(targetHighlight).not.toBeNull();
+      expect(targetHighlight?.textContent).toBe("Alice");
+    });
+
+    it("差分タイプに応じた背景色が適用される", () => {
+      const source = "value: old";
+      const target = "value: new";
+      const diffs: DiffItem[] = [
+        {
+          type: "changed",
+          path: "value",
+          sourceValue: "old",
+          targetValue: "new",
+        },
+      ];
+      const { container } = render(
+        <InlineView source={source} target={target} diffs={diffs} />,
+      );
+      const changedSpan = container.querySelector(
+        "[data-diff-type='changed']",
+      );
+      expect(changedSpan).not.toBeNull();
+      const style = (changedSpan as HTMLElement).style;
+      expect(style.backgroundColor).toBe(diffColors.changed.background);
+    });
+  });
+
+  // --- side-by-side と同じ差分箇所がハイライトされる ---
+
+  describe("side-by-side と同じ差分ロジック", () => {
+    it("JSON の括弧やコロンはハイライトされない（値部分のみ）", () => {
+      const source = '{"name": "Alice", "age": "30"}';
+      const target = '{"name": "Alice", "age": "25"}';
+      const diffs: DiffItem[] = [
+        {
+          type: "changed",
+          path: "age",
+          sourceValue: "30",
+          targetValue: "25",
+        },
+      ];
+      const { container } = render(
+        <InlineView source={source} target={target} diffs={diffs} />,
+      );
+      const sourcePane = container.querySelector(
+        "[data-testid='source-pane']",
+      );
+      const changedSpan = sourcePane?.querySelector(
+        "[data-diff-type='changed']",
+      );
+      expect(changedSpan?.textContent).toBe("30");
+    });
+
+    it("CSV のカンマや改行はハイライトされない", () => {
+      const source = "name,age\nAlice,30";
+      const target = "name,age\nAlice,25";
+      const diffs: DiffItem[] = [
+        {
+          type: "changed",
+          path: "age",
+          sourceValue: "30",
+          targetValue: "25",
+        },
+      ];
+      const { container } = render(
+        <InlineView source={source} target={target} diffs={diffs} />,
+      );
+      const sourcePane = container.querySelector(
+        "[data-testid='source-pane']",
+      );
+      const changedSpan = sourcePane?.querySelector(
+        "[data-diff-type='changed']",
+      );
+      expect(changedSpan?.textContent).toBe("30");
+    });
+
+    it("複数の差分が正しくハイライトされる", () => {
+      const source = "name: Alice, age: 30, city: Tokyo";
+      const target = "name: Bob, age: 25, city: Osaka";
+      const diffs: DiffItem[] = [
+        {
+          type: "changed",
+          path: "name",
+          sourceValue: "Alice",
+          targetValue: "Bob",
+        },
+        {
+          type: "changed",
+          path: "age",
+          sourceValue: "30",
+          targetValue: "25",
+        },
+        {
+          type: "changed",
+          path: "city",
+          sourceValue: "Tokyo",
+          targetValue: "Osaka",
+        },
+      ];
+      const { container } = render(
+        <InlineView source={source} target={target} diffs={diffs} />,
+      );
+      const sourcePane = container.querySelector(
+        "[data-testid='source-pane']",
+      );
+      const changedSpans = sourcePane?.querySelectorAll(
+        "[data-diff-type='changed']",
+      );
+      expect(changedSpans?.length).toBe(3);
+    });
+  });
+
+  // --- 差分なし ---
+
+  describe("差分なし", () => {
+    it("差分がない場合にハイライトなしで表示される", () => {
+      const text = "name,age\nAlice,30";
+      const diffs: DiffItem[] = [];
+      const { container } = render(
+        <InlineView source={text} target={text} diffs={diffs} />,
+      );
+      const highlighted = container.querySelectorAll("[data-diff-type]");
+      expect(highlighted).toHaveLength(0);
+      // テキスト自体は表示される
+      expect(screen.getAllByText(/Alice,30/).length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("差分がない場合でも source と target の両方が表示される", () => {
+      const source = "source content";
+      const target = "target content";
+      const diffs: DiffItem[] = [];
+      const { container } = render(
+        <InlineView source={source} target={target} diffs={diffs} />,
+      );
+      const sourcePane = container.querySelector(
+        "[data-testid='source-pane']",
+      );
+      const targetPane = container.querySelector(
+        "[data-testid='target-pane']",
+      );
+      expect(sourcePane?.textContent).toContain("source content");
+      expect(targetPane?.textContent).toContain("target content");
+    });
+  });
+
+  // --- 片方が空の場合 ---
+
+  describe("片方が空の場合", () => {
+    it("source が空の場合に source 側に「テキストなし」が表示される", () => {
+      const diffs: DiffItem[] = [];
+      const { container } = render(
+        <InlineView source="" target="some text" diffs={diffs} />,
+      );
+      const sourcePane = container.querySelector(
+        "[data-testid='source-pane']",
+      );
+      expect(sourcePane?.textContent).toContain("テキストなし");
+    });
+
+    it("target が空の場合に target 側に「テキストなし」が表示される", () => {
+      const diffs: DiffItem[] = [];
+      const { container } = render(
+        <InlineView source="some text" target="" diffs={diffs} />,
+      );
+      const targetPane = container.querySelector(
+        "[data-testid='target-pane']",
+      );
+      expect(targetPane?.textContent).toContain("テキストなし");
+    });
+
+    it("両方が空の場合に両側に「テキストなし」が表示される", () => {
+      const diffs: DiffItem[] = [];
+      const { container } = render(
+        <InlineView source="" target="" diffs={diffs} />,
+      );
+      const sourcePane = container.querySelector(
+        "[data-testid='source-pane']",
+      );
+      const targetPane = container.querySelector(
+        "[data-testid='target-pane']",
+      );
+      expect(sourcePane?.textContent).toContain("テキストなし");
+      expect(targetPane?.textContent).toContain("テキストなし");
+    });
+  });
+
+  // --- エッジケース ---
+
+  describe("エッジケース", () => {
+    it("Unicode/絵文字を含む値が正しくハイライトされる", () => {
+      const source = "名前: 太郎";
+      const target = "名前: 花子";
+      const diffs: DiffItem[] = [
+        {
+          type: "changed",
+          path: "名前",
+          sourceValue: "太郎",
+          targetValue: "花子",
+        },
+      ];
+      const { container } = render(
+        <InlineView source={source} target={target} diffs={diffs} />,
+      );
+      const sourcePane = container.querySelector(
+        "[data-testid='source-pane']",
+      );
+      const changedSpan = sourcePane?.querySelector(
+        "[data-diff-type='changed']",
+      );
+      expect(changedSpan?.textContent).toBe("太郎");
+    });
+
+    it("HTML 特殊文字を含むテキストがエスケープされて表示される", () => {
+      const source = "<div>old</div>";
+      const target = "<div>new</div>";
+      const diffs: DiffItem[] = [
+        {
+          type: "changed",
+          path: "content",
+          sourceValue: "old",
+          targetValue: "new",
+        },
+      ];
+      render(
+        <InlineView source={source} target={target} diffs={diffs} />,
+      );
+      // HTML がテキストとして表示される（実行されない）
+      // getAllByText を使用（source と target 両方に <div> が存在するため）
+      const matches = screen.getAllByText(/<div>/);
+      expect(matches.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("大量の差分（100件）を表示してもクラッシュしない", () => {
+      const sourceLines = Array.from(
+        { length: 100 },
+        (_, i) => `field${i}: old${i}`,
+      );
+      const targetLines = Array.from(
+        { length: 100 },
+        (_, i) => `field${i}: new${i}`,
+      );
+      const source = sourceLines.join("\n");
+      const target = targetLines.join("\n");
+      const diffs: DiffItem[] = Array.from({ length: 100 }, (_, i) => ({
+        type: "changed" as const,
+        path: `field${i}`,
+        sourceValue: `old${i}`,
+        targetValue: `new${i}`,
+      }));
+      const { container } = render(
+        <InlineView source={source} target={target} diffs={diffs} />,
+      );
+      const sourcePane = container.querySelector(
+        "[data-testid='source-pane']",
+      );
+      const changedSpans = sourcePane?.querySelectorAll(
+        "[data-diff-type='changed']",
+      );
+      expect(changedSpans?.length).toBe(100);
+    });
+  });
+});

--- a/web/src/components/InlineView.tsx
+++ b/web/src/components/InlineView.tsx
@@ -1,0 +1,71 @@
+import type { DiffItem } from "verify-ai";
+import { findHighlightSpans, splitToSegments } from "@/utils/highlightMapper";
+import { HighlightedText } from "@/components/HighlightedText";
+
+interface InlineViewProps {
+  source: string;
+  target: string;
+  diffs: readonly DiffItem[];
+}
+
+const paneStyle: React.CSSProperties = {
+  flex: 1,
+  padding: "12px",
+  fontFamily: "monospace",
+  whiteSpace: "pre-wrap",
+  wordBreak: "break-word",
+  overflow: "auto",
+  border: "1px solid #e0e0e0",
+  borderRadius: "4px",
+  minHeight: "100px",
+};
+
+const containerStyle: React.CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  gap: "16px",
+  width: "100%",
+};
+
+const emptyStyle: React.CSSProperties = {
+  color: "#9e9e9e",
+  fontStyle: "italic",
+};
+
+function Pane({
+  text,
+  diffs,
+  side,
+  testId,
+}: {
+  text: string;
+  diffs: readonly DiffItem[];
+  side: "source" | "target";
+  testId: string;
+}) {
+  if (!text) {
+    return (
+      <div data-testid={testId} style={paneStyle}>
+        <span style={emptyStyle}>テキストなし</span>
+      </div>
+    );
+  }
+
+  const spans = findHighlightSpans(text, [...diffs], side);
+  const segments = splitToSegments(text, spans);
+
+  return (
+    <div data-testid={testId} style={paneStyle}>
+      <HighlightedText segments={segments} />
+    </div>
+  );
+}
+
+export function InlineView({ source, target, diffs }: InlineViewProps) {
+  return (
+    <div style={containerStyle}>
+      <Pane text={source} diffs={diffs} side="source" testId="source-pane" />
+      <Pane text={target} diffs={diffs} side="target" testId="target-pane" />
+    </div>
+  );
+}

--- a/web/src/components/SideBySideView.test.tsx
+++ b/web/src/components/SideBySideView.test.tsx
@@ -345,7 +345,8 @@ describe("SideBySideView", () => {
         <SideBySideView source={source} target={target} diffs={diffs} />,
       );
       // HTML がテキストとして表示される（実行されない）
-      expect(screen.getByText(/<div>/)).toBeInTheDocument();
+      const matches = screen.getAllByText(/<div>/);
+      expect(matches.length).toBeGreaterThanOrEqual(1);
     });
 
     it("複数の差分が正しくハイライトされる", () => {

--- a/web/src/components/SideBySideView.test.tsx
+++ b/web/src/components/SideBySideView.test.tsx
@@ -1,0 +1,415 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@/test/test-utils";
+import { SideBySideView } from "./SideBySideView";
+import type { DiffItem } from "verify-ai";
+import { diffColors } from "@/theme/diffColors";
+
+describe("SideBySideView", () => {
+  // --- 基本レンダリング ---
+
+  describe("基本レンダリング", () => {
+    it("source と target が左右に表示される", () => {
+      const source = "name,age\nAlice,30";
+      const target = '{"name":"Alice","age":30}';
+      const diffs: DiffItem[] = [];
+      render(
+        <SideBySideView source={source} target={target} diffs={diffs} />,
+      );
+      expect(screen.getByText(/Alice,30/)).toBeInTheDocument();
+      expect(screen.getByText(/"Alice"/)).toBeInTheDocument();
+    });
+
+    it("source 側と target 側がそれぞれ独立したペインに存在する", () => {
+      const source = "source text here";
+      const target = "target text here";
+      const diffs: DiffItem[] = [];
+      const { container } = render(
+        <SideBySideView source={source} target={target} diffs={diffs} />,
+      );
+      // 左右ペインは data-testid で区別される
+      const sourcePane = container.querySelector(
+        "[data-testid='source-pane']",
+      );
+      const targetPane = container.querySelector(
+        "[data-testid='target-pane']",
+      );
+      expect(sourcePane).not.toBeNull();
+      expect(targetPane).not.toBeNull();
+      expect(sourcePane?.textContent).toContain("source text here");
+      expect(targetPane?.textContent).toContain("target text here");
+    });
+  });
+
+  // --- 差分ハイライト ---
+
+  describe("差分ハイライト", () => {
+    it("差分箇所がハイライトされる", () => {
+      const source = "name,age\nAlice,30";
+      const target = "name,age\nAlice,25";
+      const diffs: DiffItem[] = [
+        {
+          type: "changed",
+          path: "age",
+          sourceValue: "30",
+          targetValue: "25",
+        },
+      ];
+      const { container } = render(
+        <SideBySideView source={source} target={target} diffs={diffs} />,
+      );
+      const highlighted = container.querySelectorAll(
+        "[data-diff-type='changed']",
+      );
+      expect(highlighted.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("source 側で changed 値がハイライトされる", () => {
+      const source = "price: 100";
+      const target = "price: 200";
+      const diffs: DiffItem[] = [
+        {
+          type: "changed",
+          path: "price",
+          sourceValue: "100",
+          targetValue: "200",
+        },
+      ];
+      const { container } = render(
+        <SideBySideView source={source} target={target} diffs={diffs} />,
+      );
+      const sourcePane = container.querySelector(
+        "[data-testid='source-pane']",
+      );
+      const changedSpan = sourcePane?.querySelector(
+        "[data-diff-type='changed']",
+      );
+      expect(changedSpan).not.toBeNull();
+      expect(changedSpan?.textContent).toBe("100");
+    });
+
+    it("target 側で changed 値がハイライトされる", () => {
+      const source = "price: 100";
+      const target = "price: 200";
+      const diffs: DiffItem[] = [
+        {
+          type: "changed",
+          path: "price",
+          sourceValue: "100",
+          targetValue: "200",
+        },
+      ];
+      const { container } = render(
+        <SideBySideView source={source} target={target} diffs={diffs} />,
+      );
+      const targetPane = container.querySelector(
+        "[data-testid='target-pane']",
+      );
+      const changedSpan = targetPane?.querySelector(
+        "[data-diff-type='changed']",
+      );
+      expect(changedSpan).not.toBeNull();
+      expect(changedSpan?.textContent).toBe("200");
+    });
+
+    it("removed 差分で source 側のみハイライトされる", () => {
+      const source = "name,age\nBob,40";
+      const target = "name,age";
+      const diffs: DiffItem[] = [
+        {
+          type: "removed",
+          path: "name",
+          sourceValue: "Bob",
+          targetValue: null,
+        },
+      ];
+      const { container } = render(
+        <SideBySideView source={source} target={target} diffs={diffs} />,
+      );
+      const sourcePane = container.querySelector(
+        "[data-testid='source-pane']",
+      );
+      const targetPane = container.querySelector(
+        "[data-testid='target-pane']",
+      );
+      const sourceHighlight = sourcePane?.querySelector(
+        "[data-diff-type='removed']",
+      );
+      const targetHighlight = targetPane?.querySelector(
+        "[data-diff-type='removed']",
+      );
+      expect(sourceHighlight).not.toBeNull();
+      expect(sourceHighlight?.textContent).toBe("Bob");
+      expect(targetHighlight).toBeNull();
+    });
+
+    it("added 差分で target 側のみハイライトされる", () => {
+      const source = "name\n";
+      const target = "name\nAlice";
+      const diffs: DiffItem[] = [
+        {
+          type: "added",
+          path: "name",
+          sourceValue: null,
+          targetValue: "Alice",
+        },
+      ];
+      const { container } = render(
+        <SideBySideView source={source} target={target} diffs={diffs} />,
+      );
+      const sourcePane = container.querySelector(
+        "[data-testid='source-pane']",
+      );
+      const targetPane = container.querySelector(
+        "[data-testid='target-pane']",
+      );
+      const sourceHighlight = sourcePane?.querySelector(
+        "[data-diff-type='added']",
+      );
+      const targetHighlight = targetPane?.querySelector(
+        "[data-diff-type='added']",
+      );
+      expect(sourceHighlight).toBeNull();
+      expect(targetHighlight).not.toBeNull();
+      expect(targetHighlight?.textContent).toBe("Alice");
+    });
+
+    it("差分タイプに応じた背景色が適用される", () => {
+      const source = "value: old";
+      const target = "value: new";
+      const diffs: DiffItem[] = [
+        {
+          type: "changed",
+          path: "value",
+          sourceValue: "old",
+          targetValue: "new",
+        },
+      ];
+      const { container } = render(
+        <SideBySideView source={source} target={target} diffs={diffs} />,
+      );
+      const changedSpan = container.querySelector(
+        "[data-diff-type='changed']",
+      );
+      expect(changedSpan).not.toBeNull();
+      const style = (changedSpan as HTMLElement).style;
+      expect(style.backgroundColor).toBe(diffColors.changed.background);
+    });
+  });
+
+  // --- 値部分のみハイライト（フォーマット構文を含まない） ---
+
+  describe("ハイライトは値部分のみ", () => {
+    it("JSON の括弧やコロンはハイライトされない", () => {
+      const source = '{"name": "Alice", "age": "30"}';
+      const target = '{"name": "Alice", "age": "25"}';
+      const diffs: DiffItem[] = [
+        {
+          type: "changed",
+          path: "age",
+          sourceValue: "30",
+          targetValue: "25",
+        },
+      ];
+      const { container } = render(
+        <SideBySideView source={source} target={target} diffs={diffs} />,
+      );
+      const sourcePane = container.querySelector(
+        "[data-testid='source-pane']",
+      );
+      const changedSpan = sourcePane?.querySelector(
+        "[data-diff-type='changed']",
+      );
+      // ハイライトされるのは値 "30" のみ、括弧やコロンは含まない
+      expect(changedSpan?.textContent).toBe("30");
+    });
+
+    it("CSV のカンマや改行はハイライトされない", () => {
+      const source = "name,age\nAlice,30";
+      const target = "name,age\nAlice,25";
+      const diffs: DiffItem[] = [
+        {
+          type: "changed",
+          path: "age",
+          sourceValue: "30",
+          targetValue: "25",
+        },
+      ];
+      const { container } = render(
+        <SideBySideView source={source} target={target} diffs={diffs} />,
+      );
+      const sourcePane = container.querySelector(
+        "[data-testid='source-pane']",
+      );
+      const changedSpan = sourcePane?.querySelector(
+        "[data-diff-type='changed']",
+      );
+      expect(changedSpan?.textContent).toBe("30");
+    });
+  });
+
+  // --- 差分なし ---
+
+  describe("差分なし", () => {
+    it("差分がない場合にハイライトなしで表示される", () => {
+      const text = "name,age\nAlice,30";
+      const diffs: DiffItem[] = [];
+      const { container } = render(
+        <SideBySideView source={text} target={text} diffs={diffs} />,
+      );
+      const highlighted = container.querySelectorAll("[data-diff-type]");
+      expect(highlighted).toHaveLength(0);
+      // テキスト自体は表示される
+      expect(screen.getAllByText(/Alice,30/).length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  // --- 片方が空 ---
+
+  describe("片方が空の場合", () => {
+    it("source が空の場合に source 側に「テキストなし」が表示される", () => {
+      const diffs: DiffItem[] = [];
+      const { container } = render(
+        <SideBySideView source="" target="some text" diffs={diffs} />,
+      );
+      const sourcePane = container.querySelector(
+        "[data-testid='source-pane']",
+      );
+      expect(sourcePane?.textContent).toContain("テキストなし");
+    });
+
+    it("target が空の場合に target 側に「テキストなし」が表示される", () => {
+      const diffs: DiffItem[] = [];
+      const { container } = render(
+        <SideBySideView source="some text" target="" diffs={diffs} />,
+      );
+      const targetPane = container.querySelector(
+        "[data-testid='target-pane']",
+      );
+      expect(targetPane?.textContent).toContain("テキストなし");
+    });
+
+    it("両方が空の場合に両側に「テキストなし」が表示される", () => {
+      const diffs: DiffItem[] = [];
+      const { container } = render(
+        <SideBySideView source="" target="" diffs={diffs} />,
+      );
+      const sourcePane = container.querySelector(
+        "[data-testid='source-pane']",
+      );
+      const targetPane = container.querySelector(
+        "[data-testid='target-pane']",
+      );
+      expect(sourcePane?.textContent).toContain("テキストなし");
+      expect(targetPane?.textContent).toContain("テキストなし");
+    });
+  });
+
+  // --- エッジケース ---
+
+  describe("エッジケース", () => {
+    it("Unicode/絵文字を含む値が正しくハイライトされる", () => {
+      const source = "名前: 太郎";
+      const target = "名前: 花子";
+      const diffs: DiffItem[] = [
+        {
+          type: "changed",
+          path: "名前",
+          sourceValue: "太郎",
+          targetValue: "花子",
+        },
+      ];
+      const { container } = render(
+        <SideBySideView source={source} target={target} diffs={diffs} />,
+      );
+      const sourcePane = container.querySelector(
+        "[data-testid='source-pane']",
+      );
+      const changedSpan = sourcePane?.querySelector(
+        "[data-diff-type='changed']",
+      );
+      expect(changedSpan?.textContent).toBe("太郎");
+    });
+
+    it("HTML 特殊文字を含むテキストがエスケープされて表示される", () => {
+      const source = '<div>old</div>';
+      const target = '<div>new</div>';
+      const diffs: DiffItem[] = [
+        {
+          type: "changed",
+          path: "content",
+          sourceValue: "old",
+          targetValue: "new",
+        },
+      ];
+      render(
+        <SideBySideView source={source} target={target} diffs={diffs} />,
+      );
+      // HTML がテキストとして表示される（実行されない）
+      expect(screen.getByText(/<div>/)).toBeInTheDocument();
+    });
+
+    it("複数の差分が正しくハイライトされる", () => {
+      const source = "name: Alice, age: 30, city: Tokyo";
+      const target = "name: Bob, age: 25, city: Osaka";
+      const diffs: DiffItem[] = [
+        {
+          type: "changed",
+          path: "name",
+          sourceValue: "Alice",
+          targetValue: "Bob",
+        },
+        {
+          type: "changed",
+          path: "age",
+          sourceValue: "30",
+          targetValue: "25",
+        },
+        {
+          type: "changed",
+          path: "city",
+          sourceValue: "Tokyo",
+          targetValue: "Osaka",
+        },
+      ];
+      const { container } = render(
+        <SideBySideView source={source} target={target} diffs={diffs} />,
+      );
+      const sourcePane = container.querySelector(
+        "[data-testid='source-pane']",
+      );
+      const changedSpans = sourcePane?.querySelectorAll(
+        "[data-diff-type='changed']",
+      );
+      expect(changedSpans?.length).toBe(3);
+    });
+
+    it("大量の差分（100件）を表示してもクラッシュしない", () => {
+      const sourceLines = Array.from(
+        { length: 100 },
+        (_, i) => `field${i}: old${i}`,
+      );
+      const targetLines = Array.from(
+        { length: 100 },
+        (_, i) => `field${i}: new${i}`,
+      );
+      const source = sourceLines.join("\n");
+      const target = targetLines.join("\n");
+      const diffs: DiffItem[] = Array.from({ length: 100 }, (_, i) => ({
+        type: "changed" as const,
+        path: `field${i}`,
+        sourceValue: `old${i}`,
+        targetValue: `new${i}`,
+      }));
+      const { container } = render(
+        <SideBySideView source={source} target={target} diffs={diffs} />,
+      );
+      const sourcePane = container.querySelector(
+        "[data-testid='source-pane']",
+      );
+      const changedSpans = sourcePane?.querySelectorAll(
+        "[data-diff-type='changed']",
+      );
+      expect(changedSpans?.length).toBe(100);
+    });
+  });
+});

--- a/web/src/components/SideBySideView.tsx
+++ b/web/src/components/SideBySideView.tsx
@@ -1,0 +1,70 @@
+import type { DiffItem } from "verify-ai";
+import { findHighlightSpans, splitToSegments } from "@/utils/highlightMapper";
+import { HighlightedText } from "@/components/HighlightedText";
+
+interface SideBySideViewProps {
+  source: string;
+  target: string;
+  diffs: readonly DiffItem[];
+}
+
+const paneStyle: React.CSSProperties = {
+  flex: 1,
+  padding: "12px",
+  fontFamily: "monospace",
+  whiteSpace: "pre-wrap",
+  wordBreak: "break-word",
+  overflow: "auto",
+  border: "1px solid #e0e0e0",
+  borderRadius: "4px",
+  minHeight: "100px",
+};
+
+const containerStyle: React.CSSProperties = {
+  display: "flex",
+  gap: "16px",
+  width: "100%",
+};
+
+const emptyStyle: React.CSSProperties = {
+  color: "#9e9e9e",
+  fontStyle: "italic",
+};
+
+function Pane({
+  text,
+  diffs,
+  side,
+  testId,
+}: {
+  text: string;
+  diffs: readonly DiffItem[];
+  side: "source" | "target";
+  testId: string;
+}) {
+  if (!text) {
+    return (
+      <div data-testid={testId} style={paneStyle}>
+        <span style={emptyStyle}>テキストなし</span>
+      </div>
+    );
+  }
+
+  const spans = findHighlightSpans(text, [...diffs], side);
+  const segments = splitToSegments(text, spans);
+
+  return (
+    <div data-testid={testId} style={paneStyle}>
+      <HighlightedText segments={segments} />
+    </div>
+  );
+}
+
+export function SideBySideView({ source, target, diffs }: SideBySideViewProps) {
+  return (
+    <div style={containerStyle}>
+      <Pane text={source} diffs={diffs} side="source" testId="source-pane" />
+      <Pane text={target} diffs={diffs} side="target" testId="target-pane" />
+    </div>
+  );
+}

--- a/web/src/components/index.ts
+++ b/web/src/components/index.ts
@@ -3,4 +3,5 @@ export { ResultSummary } from "./ResultSummary";
 export { DiffList } from "./DiffList";
 export { HighlightedText } from "./HighlightedText";
 export { SideBySideView } from "./SideBySideView";
+export { InlineView } from "./InlineView";
 export { DiffViewSwitcher } from "./DiffViewSwitcher";

--- a/web/src/components/index.ts
+++ b/web/src/components/index.ts
@@ -1,3 +1,6 @@
 export { CompareForm } from "./CompareForm";
 export { ResultSummary } from "./ResultSummary";
 export { DiffList } from "./DiffList";
+export { HighlightedText } from "./HighlightedText";
+export { SideBySideView } from "./SideBySideView";
+export { DiffViewSwitcher } from "./DiffViewSwitcher";

--- a/web/src/stores/compareStore.test.ts
+++ b/web/src/stores/compareStore.test.ts
@@ -10,6 +10,7 @@ describe("useCompareStore", () => {
       result: null,
       isComparing: false,
       error: null,
+      viewMode: "side-by-side",
     });
   });
 
@@ -184,6 +185,42 @@ describe("useCompareStore", () => {
     });
   });
 
+  // --- viewMode ---
+
+  describe("viewMode", () => {
+    it("デフォルトが 'side-by-side' である", () => {
+      const state = useCompareStore.getState();
+      expect(state.viewMode).toBe("side-by-side");
+    });
+
+    it("setViewMode で 'list' に切替可能", () => {
+      const { setViewMode } = useCompareStore.getState();
+      setViewMode("list");
+      expect(useCompareStore.getState().viewMode).toBe("list");
+    });
+
+    it("setViewMode で 'inline' に切替可能", () => {
+      const { setViewMode } = useCompareStore.getState();
+      setViewMode("inline");
+      expect(useCompareStore.getState().viewMode).toBe("inline");
+    });
+
+    it("setViewMode で 'side-by-side' に切替可能", () => {
+      const { setViewMode } = useCompareStore.getState();
+      setViewMode("list");
+      setViewMode("side-by-side");
+      expect(useCompareStore.getState().viewMode).toBe("side-by-side");
+    });
+
+    it("viewMode の変更が他の状態に影響しない", () => {
+      const { setSource, setViewMode } = useCompareStore.getState();
+      setSource("hello");
+      setViewMode("inline");
+      expect(useCompareStore.getState().source).toBe("hello");
+      expect(useCompareStore.getState().viewMode).toBe("inline");
+    });
+  });
+
   // --- reset ---
 
   describe("reset", () => {
@@ -199,6 +236,7 @@ describe("useCompareStore", () => {
         targetFormat: { type: "plain", confidence: 1.0 },
       });
       state.setError("error");
+      state.setViewMode("inline");
 
       useCompareStore.getState().reset();
 
@@ -208,6 +246,7 @@ describe("useCompareStore", () => {
       expect(resetState.result).toBeNull();
       expect(resetState.isComparing).toBe(false);
       expect(resetState.error).toBeNull();
+      expect(resetState.viewMode).toBe("side-by-side");
     });
   });
 });

--- a/web/src/stores/compareStore.ts
+++ b/web/src/stores/compareStore.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 import type { ComparisonResult } from "verify-ai";
+import type { DiffViewMode } from "@/utils/highlightMapper";
 
 interface CompareState {
   source: string;
@@ -7,11 +8,13 @@ interface CompareState {
   result: ComparisonResult | null;
   isComparing: boolean;
   error: string | null;
+  viewMode: DiffViewMode;
   setSource: (source: string) => void;
   setTarget: (target: string) => void;
   setResult: (result: ComparisonResult | null) => void;
   setIsComparing: (isComparing: boolean) => void;
   setError: (error: string | null) => void;
+  setViewMode: (viewMode: DiffViewMode) => void;
   reset: () => void;
 }
 
@@ -21,6 +24,7 @@ const initialState = {
   result: null,
   isComparing: false,
   error: null,
+  viewMode: "side-by-side" as DiffViewMode,
 };
 
 export const useCompareStore = create<CompareState>((set) => ({
@@ -30,5 +34,6 @@ export const useCompareStore = create<CompareState>((set) => ({
   setResult: (result) => set({ result }),
   setIsComparing: (isComparing) => set({ isComparing }),
   setError: (error) => set({ error }),
+  setViewMode: (viewMode) => set({ viewMode }),
   reset: () => set(initialState),
 }));

--- a/web/src/theme/diffColors.ts
+++ b/web/src/theme/diffColors.ts
@@ -1,14 +1,14 @@
 export const diffColors = {
   added: {
-    background: "#fff8e1",
-    text: "#e65100",
+    background: "rgb(255, 248, 225)",
+    text: "rgb(230, 81, 0)",
   },
   removed: {
-    background: "#ffebee",
-    text: "#b71c1c",
+    background: "rgb(255, 235, 238)",
+    text: "rgb(183, 28, 28)",
   },
   changed: {
-    background: "#e3f2fd",
-    text: "#0d47a1",
+    background: "rgb(227, 242, 253)",
+    text: "rgb(13, 71, 161)",
   },
 } as const;

--- a/web/src/utils/highlightMapper.test.ts
+++ b/web/src/utils/highlightMapper.test.ts
@@ -265,7 +265,7 @@ describe("splitToSegments", () => {
         },
       ];
       const segments = splitToSegments(text, spans);
-      expect(segments).toHaveLength(5);
+      expect(segments).toHaveLength(4);
       expect(segments[0]).toEqual({ text: "Alice", highlight: spans[0] });
       expect(segments[1]).toEqual({ text: " is ", highlight: null });
       expect(segments[2]).toEqual({ text: "30", highlight: spans[1] });

--- a/web/src/utils/highlightMapper.test.ts
+++ b/web/src/utils/highlightMapper.test.ts
@@ -4,7 +4,7 @@ import {
   findHighlightSpans,
   splitToSegments,
 } from "./highlightMapper";
-import type { HighlightSpan, TextSegment } from "./highlightMapper";
+import type { HighlightSpan } from "./highlightMapper";
 
 describe("findHighlightSpans", () => {
   // --- 基本的な位置特定 ---

--- a/web/src/utils/highlightMapper.test.ts
+++ b/web/src/utils/highlightMapper.test.ts
@@ -1,0 +1,337 @@
+import { describe, it, expect } from "vitest";
+import type { DiffItem } from "verify-ai";
+import {
+  findHighlightSpans,
+  splitToSegments,
+} from "./highlightMapper";
+import type { HighlightSpan, TextSegment } from "./highlightMapper";
+
+describe("findHighlightSpans", () => {
+  // --- 基本的な位置特定 ---
+
+  describe("基本的な位置特定", () => {
+    it("changed の sourceValue が source テキスト内で正しい位置を返す", () => {
+      const text = '{"name": "Tokyo"}';
+      const diffs: DiffItem[] = [
+        { type: "changed", path: "name", sourceValue: "Tokyo", targetValue: "Osaka" },
+      ];
+      const spans = findHighlightSpans(text, diffs, "source");
+      expect(spans).toHaveLength(1);
+      expect(spans[0].start).toBe(text.indexOf("Tokyo"));
+      expect(spans[0].end).toBe(text.indexOf("Tokyo") + "Tokyo".length);
+      expect(spans[0].diffType).toBe("changed");
+    });
+
+    it("changed の targetValue が target テキスト内で正しい位置を返す", () => {
+      const text = '{"name": "Osaka"}';
+      const diffs: DiffItem[] = [
+        { type: "changed", path: "name", sourceValue: "Tokyo", targetValue: "Osaka" },
+      ];
+      const spans = findHighlightSpans(text, diffs, "target");
+      expect(spans).toHaveLength(1);
+      expect(spans[0].start).toBe(text.indexOf("Osaka"));
+      expect(spans[0].end).toBe(text.indexOf("Osaka") + "Osaka".length);
+      expect(spans[0].diffType).toBe("changed");
+    });
+
+    it("removed の sourceValue が source 側で位置を返す", () => {
+      const text = "name,age\nAlice,30";
+      const diffs: DiffItem[] = [
+        { type: "removed", path: "age", sourceValue: "30", targetValue: null },
+      ];
+      const spans = findHighlightSpans(text, diffs, "source");
+      expect(spans).toHaveLength(1);
+      expect(spans[0].diffType).toBe("removed");
+      expect(text.slice(spans[0].start, spans[0].end)).toBe("30");
+    });
+
+    it("removed の DiffItem は target 側で空配列を返す", () => {
+      const text = "name\nAlice";
+      const diffs: DiffItem[] = [
+        { type: "removed", path: "age", sourceValue: "30", targetValue: null },
+      ];
+      const spans = findHighlightSpans(text, diffs, "target");
+      expect(spans).toHaveLength(0);
+    });
+
+    it("added の targetValue が target 側で位置を返す", () => {
+      const text = '{"email": "a@b.com"}';
+      const diffs: DiffItem[] = [
+        { type: "added", path: "email", sourceValue: null, targetValue: "a@b.com" },
+      ];
+      const spans = findHighlightSpans(text, diffs, "target");
+      expect(spans).toHaveLength(1);
+      expect(spans[0].diffType).toBe("added");
+      expect(text.slice(spans[0].start, spans[0].end)).toBe("a@b.com");
+    });
+
+    it("added の DiffItem は source 側で空配列を返す", () => {
+      const text = '{"name": "Alice"}';
+      const diffs: DiffItem[] = [
+        { type: "added", path: "email", sourceValue: null, targetValue: "a@b.com" },
+      ];
+      const spans = findHighlightSpans(text, diffs, "source");
+      expect(spans).toHaveLength(0);
+    });
+  });
+
+  // --- 複数差分 ---
+
+  describe("複数差分", () => {
+    it("複数の DiffItem からそれぞれの位置を返す", () => {
+      const text = '{"name": "Alice", "age": "30"}';
+      const diffs: DiffItem[] = [
+        { type: "changed", path: "name", sourceValue: "Alice", targetValue: "Bob" },
+        { type: "changed", path: "age", sourceValue: "30", targetValue: "25" },
+      ];
+      const spans = findHighlightSpans(text, diffs, "source");
+      expect(spans).toHaveLength(2);
+      expect(text.slice(spans[0].start, spans[0].end)).toBe("Alice");
+      expect(text.slice(spans[1].start, spans[1].end)).toBe("30");
+    });
+
+    it("span が start 昇順でソートされている", () => {
+      const text = "age,name\n30,Alice";
+      const diffs: DiffItem[] = [
+        { type: "changed", path: "name", sourceValue: "Alice", targetValue: "Bob" },
+        { type: "changed", path: "age", sourceValue: "30", targetValue: "25" },
+      ];
+      const spans = findHighlightSpans(text, diffs, "source");
+      expect(spans.length).toBeGreaterThanOrEqual(2);
+      for (let i = 1; i < spans.length; i++) {
+        expect(spans[i].start).toBeGreaterThanOrEqual(spans[i - 1].start);
+      }
+    });
+  });
+
+  // --- 重複値の順序保持 ---
+
+  describe("同じ値が複数回出現する場合", () => {
+    it("同一値の重複出現で順序を保持して位置を返す", () => {
+      const text = "name,name2\nTokyo,Tokyo";
+      const diffs: DiffItem[] = [
+        { type: "changed", path: "name", sourceValue: "Tokyo", targetValue: "Osaka" },
+        { type: "changed", path: "name2", sourceValue: "Tokyo", targetValue: "Kyoto" },
+      ];
+      const spans = findHighlightSpans(text, diffs, "source");
+      expect(spans).toHaveLength(2);
+      // 2つの "Tokyo" は異なる位置
+      expect(spans[0].start).not.toBe(spans[1].start);
+    });
+  });
+
+  // --- path が空文字の場合（テキストベース差分） ---
+
+  describe("path が空文字の場合", () => {
+    it("path が空文字の場合に行単位で検索する", () => {
+      const text = "line1\nline2\nline3";
+      const diffs: DiffItem[] = [
+        { type: "removed", path: "", sourceValue: "line2", targetValue: null },
+      ];
+      const spans = findHighlightSpans(text, diffs, "source");
+      expect(spans).toHaveLength(1);
+      expect(text.slice(spans[0].start, spans[0].end)).toBe("line2");
+    });
+  });
+
+  // --- 値が見つからない場合 ---
+
+  describe("値が見つからない場合", () => {
+    it("テキスト内に値が存在しない場合は空配列を返す", () => {
+      const text = '{"name": "Alice"}';
+      const diffs: DiffItem[] = [
+        { type: "changed", path: "name", sourceValue: "NotInText", targetValue: "Bob" },
+      ];
+      const spans = findHighlightSpans(text, diffs, "source");
+      expect(spans).toHaveLength(0);
+    });
+  });
+
+  // --- エッジケース ---
+
+  describe("エッジケース", () => {
+    it("空文字列のテキストに対して空配列を返す", () => {
+      const diffs: DiffItem[] = [
+        { type: "changed", path: "name", sourceValue: "Alice", targetValue: "Bob" },
+      ];
+      const spans = findHighlightSpans("", diffs, "source");
+      expect(spans).toHaveLength(0);
+    });
+
+    it("空の diffs 配列に対して空配列を返す", () => {
+      const spans = findHighlightSpans("some text", [], "source");
+      expect(spans).toHaveLength(0);
+    });
+
+    it("sourceValue/targetValue が空文字列の場合は空配列を返す", () => {
+      const text = '{"name": ""}';
+      const diffs: DiffItem[] = [
+        { type: "changed", path: "name", sourceValue: "", targetValue: "Bob" },
+      ];
+      const spans = findHighlightSpans(text, diffs, "source");
+      expect(spans).toHaveLength(0);
+    });
+
+    it("Unicode 文字を含む値の位置を正しく特定する", () => {
+      const text = "name\n太郎";
+      const diffs: DiffItem[] = [
+        { type: "changed", path: "name", sourceValue: "太郎", targetValue: "花子" },
+      ];
+      const spans = findHighlightSpans(text, diffs, "source");
+      expect(spans).toHaveLength(1);
+      expect(text.slice(spans[0].start, spans[0].end)).toBe("太郎");
+    });
+
+    it("特殊文字（括弧、カンマ等）を含む値の位置を正しく特定する", () => {
+      const text = '{"desc": "price (100)"}';
+      const diffs: DiffItem[] = [
+        { type: "changed", path: "desc", sourceValue: "price (100)", targetValue: "price (200)" },
+      ];
+      const spans = findHighlightSpans(text, diffs, "source");
+      expect(spans).toHaveLength(1);
+      expect(text.slice(spans[0].start, spans[0].end)).toBe("price (100)");
+    });
+
+    it("diffItem への参照を保持する", () => {
+      const text = '{"name": "Alice"}';
+      const diff: DiffItem = { type: "changed", path: "name", sourceValue: "Alice", targetValue: "Bob" };
+      const spans = findHighlightSpans(text, [diff], "source");
+      expect(spans).toHaveLength(1);
+      expect(spans[0].diffItem).toBe(diff);
+    });
+  });
+});
+
+describe("splitToSegments", () => {
+  // --- 基本的なセグメント分割 ---
+
+  describe("基本的なセグメント分割", () => {
+    it("ハイライトなしのテキストを1つの通常セグメントとして返す", () => {
+      const segments = splitToSegments("hello world", []);
+      expect(segments).toHaveLength(1);
+      expect(segments[0].text).toBe("hello world");
+      expect(segments[0].highlight).toBeNull();
+    });
+
+    it("テキスト全体がハイライトされる場合に1つのハイライトセグメントを返す", () => {
+      const span: HighlightSpan = {
+        start: 0,
+        end: 5,
+        diffType: "changed",
+        diffItem: { type: "changed", path: "x", sourceValue: "hello", targetValue: "world" },
+      };
+      const segments = splitToSegments("hello", [span]);
+      expect(segments).toHaveLength(1);
+      expect(segments[0].text).toBe("hello");
+      expect(segments[0].highlight).not.toBeNull();
+      expect(segments[0].highlight?.diffType).toBe("changed");
+    });
+
+    it("テキストの一部がハイライトされる場合に3つのセグメントを返す", () => {
+      const span: HighlightSpan = {
+        start: 6,
+        end: 11,
+        diffType: "changed",
+        diffItem: { type: "changed", path: "x", sourceValue: "world", targetValue: "earth" },
+      };
+      const segments = splitToSegments("hello world end", [span]);
+      expect(segments).toHaveLength(3);
+      expect(segments[0].text).toBe("hello ");
+      expect(segments[0].highlight).toBeNull();
+      expect(segments[1].text).toBe("world");
+      expect(segments[1].highlight).not.toBeNull();
+      expect(segments[2].text).toBe(" end");
+      expect(segments[2].highlight).toBeNull();
+    });
+  });
+
+  // --- 複数ハイライト ---
+
+  describe("複数ハイライト", () => {
+    it("複数の span で正しくセグメント分割される", () => {
+      const text = "Alice is 30 years old";
+      const spans: HighlightSpan[] = [
+        {
+          start: 0,
+          end: 5,
+          diffType: "changed",
+          diffItem: { type: "changed", path: "name", sourceValue: "Alice", targetValue: "Bob" },
+        },
+        {
+          start: 9,
+          end: 11,
+          diffType: "changed",
+          diffItem: { type: "changed", path: "age", sourceValue: "30", targetValue: "25" },
+        },
+      ];
+      const segments = splitToSegments(text, spans);
+      expect(segments).toHaveLength(5);
+      expect(segments[0]).toEqual({ text: "Alice", highlight: spans[0] });
+      expect(segments[1]).toEqual({ text: " is ", highlight: null });
+      expect(segments[2]).toEqual({ text: "30", highlight: spans[1] });
+      expect(segments[3]).toEqual({ text: " years old", highlight: null });
+    });
+  });
+
+  // --- エッジケース ---
+
+  describe("エッジケース", () => {
+    it("空文字列のテキストに対して空配列を返す", () => {
+      const segments = splitToSegments("", []);
+      expect(segments).toHaveLength(0);
+    });
+
+    it("テキスト先頭からハイライトが始まる場合", () => {
+      const span: HighlightSpan = {
+        start: 0,
+        end: 3,
+        diffType: "added",
+        diffItem: { type: "added", path: "x", sourceValue: null, targetValue: "foo" },
+      };
+      const segments = splitToSegments("foo bar", [span]);
+      expect(segments).toHaveLength(2);
+      expect(segments[0].text).toBe("foo");
+      expect(segments[0].highlight).not.toBeNull();
+      expect(segments[1].text).toBe(" bar");
+      expect(segments[1].highlight).toBeNull();
+    });
+
+    it("テキスト末尾でハイライトが終わる場合", () => {
+      const span: HighlightSpan = {
+        start: 4,
+        end: 7,
+        diffType: "removed",
+        diffItem: { type: "removed", path: "x", sourceValue: "bar", targetValue: null },
+      };
+      const segments = splitToSegments("foo bar", [span]);
+      expect(segments).toHaveLength(2);
+      expect(segments[0].text).toBe("foo ");
+      expect(segments[0].highlight).toBeNull();
+      expect(segments[1].text).toBe("bar");
+      expect(segments[1].highlight).not.toBeNull();
+    });
+
+    it("隣接するハイライトが正しく分割される", () => {
+      const spans: HighlightSpan[] = [
+        {
+          start: 0,
+          end: 3,
+          diffType: "changed",
+          diffItem: { type: "changed", path: "a", sourceValue: "abc", targetValue: "xyz" },
+        },
+        {
+          start: 3,
+          end: 6,
+          diffType: "added",
+          diffItem: { type: "added", path: "b", sourceValue: null, targetValue: "def" },
+        },
+      ];
+      const segments = splitToSegments("abcdef", spans);
+      expect(segments).toHaveLength(2);
+      expect(segments[0].text).toBe("abc");
+      expect(segments[0].highlight?.diffType).toBe("changed");
+      expect(segments[1].text).toBe("def");
+      expect(segments[1].highlight?.diffType).toBe("added");
+    });
+  });
+});

--- a/web/src/utils/highlightMapper.ts
+++ b/web/src/utils/highlightMapper.ts
@@ -1,0 +1,102 @@
+import type { DiffItem } from "verify-ai";
+
+export interface HighlightSpan {
+  start: number;
+  end: number;
+  diffType: "added" | "removed" | "changed";
+  diffItem: DiffItem;
+}
+
+export interface TextSegment {
+  text: string;
+  highlight: HighlightSpan | null;
+}
+
+export type DiffViewMode = "list" | "side-by-side" | "inline";
+
+/**
+ * DiffItem[] と元テキストから HighlightSpan[] を生成する。
+ * side に応じて sourceValue / targetValue を検索対象として使用する。
+ * 同一値の重複出現は前回マッチ位置以降を検索して順序を保持する。
+ */
+export function findHighlightSpans(
+  text: string,
+  diffs: DiffItem[],
+  side: "source" | "target"
+): HighlightSpan[] {
+  if (!text || diffs.length === 0) {
+    return [];
+  }
+
+  const spans: HighlightSpan[] = [];
+  // 値ごとの検索開始位置を追跡して重複に対応
+  const searchFrom = new Map<string, number>();
+
+  for (const diff of diffs) {
+    const value = side === "source" ? diff.sourceValue : diff.targetValue;
+
+    if (value === null || value === undefined || value === "") {
+      continue;
+    }
+
+    const from = searchFrom.get(value) ?? 0;
+    const idx = text.indexOf(value, from);
+
+    if (idx === -1) {
+      continue;
+    }
+
+    searchFrom.set(value, idx + value.length);
+
+    spans.push({
+      start: idx,
+      end: idx + value.length,
+      diffType: diff.type as "added" | "removed" | "changed",
+      diffItem: diff,
+    });
+  }
+
+  return spans.sort((a, b) => a.start - b.start);
+}
+
+/**
+ * テキストを HighlightSpan[] に基づいてセグメントに分割する。
+ * spans は start 昇順でソート済みであることを前提とする。
+ */
+export function splitToSegments(
+  text: string,
+  spans: HighlightSpan[]
+): TextSegment[] {
+  if (!text) {
+    return [];
+  }
+
+  const sortedSpans = [...spans].sort((a, b) => a.start - b.start);
+  const segments: TextSegment[] = [];
+  let cursor = 0;
+
+  for (const span of sortedSpans) {
+    if (span.start > cursor) {
+      segments.push({
+        text: text.slice(cursor, span.start),
+        highlight: null,
+      });
+    }
+
+    segments.push({
+      text: text.slice(span.start, span.end),
+      highlight: span,
+    });
+
+    cursor = span.end;
+  }
+
+  if (cursor < text.length) {
+    segments.push({
+      text: text.slice(cursor),
+      highlight: null,
+    });
+  }
+
+  return segments;
+}


### PR DESCRIPTION
## Summary
- 比較結果の差分箇所を**元テキスト上でハイライト表示**する機能を追加
- **Side-by-side ビュー**: 左右に source/target を並べ、差分値をタイプ別に色分けハイライト
- **インラインビュー**: 上下に source/target を並べ、同じハイライトを表示
- **ビュー切替UI**: リスト / side-by-side / inline の3モードを ToggleButton で1クリック切替
- CSV vs JSON など**異フォーマット間でも**、データレベルの差分箇所が元テキスト上で視覚的に確認可能
- **ホバー連動**: ハイライト箇所にカーソルを合わせると、反対側の対応箇所がチカチカ点滅

## 新規ファイル
- `web/src/utils/highlightMapper.ts` — DiffItem[] から元テキスト内の位置を特定し HighlightSpan[] に変換
- `web/src/components/HighlightedText.tsx` — TextSegment[] をハイライト付き span で描画（ホバー点滅対応）
- `web/src/components/SideBySideView.tsx` — 左右並列ビュー
- `web/src/components/InlineView.tsx` — 上下並列ビュー
- `web/src/components/DiffViewSwitcher.tsx` — MUI ToggleButtonGroup による3ビュー切替

## 変更ファイル
- `web/src/App.tsx` — DiffViewSwitcher + ビューモード切替を統合
- `web/src/stores/compareStore.ts` — viewMode + hoveredDiffItem 状態追加
- `web/src/components/index.ts` — 新コンポーネントの re-export

## 動作確認用テストデータ

### パターン1: CSV vs JSON（異フォーマット・値変更あり）

**Source (CSV)**:
```
名前,年齢,都市
田中太郎,30,東京
佐藤花子,25,大阪
```

**Target (JSON)**:
```json
[
  {"名前": "田中太郎", "年齢": "31", "都市": "東京"},
  {"名前": "佐藤花子", "年齢": "25", "都市": "名古屋"}
]
```

期待: 「30→31」「大阪→名古屋」がハイライトされる

### パターン2: JSON vs JSON（同フォーマット・複数変更）

**Source**:
```json
{"product": "ノートPC", "price": "98000", "stock": "15", "category": "電子機器"}
```

**Target**:
```json
{"product": "ノートPC", "price": "89000", "stock": "20", "category": "電子機器"}
```

期待: 「98000→89000」「15→20」がハイライトされる

### パターン3: CSV vs CSV（追加・削除あり）

**Source**:
```
name,email,role
Alice,alice@example.com,admin
Bob,bob@example.com,user
Charlie,charlie@example.com,user
```

**Target**:
```
name,email,role
Alice,alice@example.com,manager
Dave,dave@example.com,user
```

期待: removed（Bob, Charlie 行）、changed（admin→manager）、added（Dave 行）が色分けハイライト

## Test plan
- [x] 186テスト全通過（新規52テスト + 既存134テスト回帰なし）
- [x] `npm run build` ビルド成功（TypeScript型チェック + Vite）
- [x] highlightMapper: 位置特定、重複値順序保持、空path、値未発見
- [x] SideBySideView: 左右表示、差分ハイライト、値のみハイライト、エッジケース
- [x] InlineView: 上下表示、side-by-sideと同一ハイライト
- [x] DiffViewSwitcher: 3モード表示、切替、デフォルト選択
- [ ] ホバー時に反対側の対応箇所が点滅することを目視確認

Closes #16
