### PR TITLE
chore: ルート Makefile に make dev ターゲット追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
-.PHONY: test build lint coverage
+.PHONY: dev test build lint coverage
+
+dev:
+	cd web && npm run dev
 
 test:
 	npx vitest run


### PR DESCRIPTION
## Summary

- ルート Makefile に `make dev` ターゲットを追加（`cd web && npm run dev` を実行）
- プロジェクトルートから `make dev` で Web UI 開発サーバーを起動可能に

## Test plan

- [x] `make dev` で Vite 開発サーバーが起動し `http://localhost:5173` でアクセス可能

🤖 Generated with [Claude Code](https://claude.com/claude-code)